### PR TITLE
Reports 128-bit ids to Zipkin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ javadocJar.enabled = false
 ext {
     slf4jVersion = '1.7.7'
     servletApiVersion = '3.1.0'
-    zipkinVersion = '1.11.1'
+    zipkinVersion = '1.16.2'
 
     junitVersion = '4.11'
     mockitoVersion = '1.9.5'

--- a/wingtips-core/src/test/java/com/nike/wingtips/TraceAndSpanIdGeneratorTest.java
+++ b/wingtips-core/src/test/java/com/nike/wingtips/TraceAndSpanIdGeneratorTest.java
@@ -231,7 +231,7 @@ public class TraceAndSpanIdGeneratorTest {
 
     @DataProvider(value = {
         "                                      ", // less than 16 chars
-        "123e4567-e89b-12d3-a456-426655440000  ", // longer than 32 chars
+        "123e4567-e89b-12d3-a456-426655440000  ", // UUID format (hyphens and also >32 chars)
         "/                                     ", // before '0' char
         ":                                     ", // after '9' char
         "`                                     ", // before 'a' char
@@ -240,11 +240,22 @@ public class TraceAndSpanIdGeneratorTest {
     }, splitBy = "\\|")
     @Test
     public void unsignedLowerHexStringToLong_throws_NumberFormatException_for_illegal_args(final String badHexString) {
-        // when
+        // when selecting right-most 16 characters
         Throwable ex = catchThrowable(new ThrowableAssert.ThrowingCallable() {
             @Override
             public void call() throws Throwable {
                 TraceAndSpanIdGenerator.unsignedLowerHexStringToLong(badHexString);
+            }
+        });
+
+        // then
+        assertThat(ex).isInstanceOf(NumberFormatException.class);
+
+        // when selecting 16 characters at offset 0
+        ex = catchThrowable(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                TraceAndSpanIdGenerator.unsignedLowerHexStringToLong(badHexString, 0);
             }
         });
 

--- a/wingtips-zipkin/src/main/java/com/nike/wingtips/zipkin/util/WingtipsToZipkinSpanConverterDefaultImpl.java
+++ b/wingtips-zipkin/src/main/java/com/nike/wingtips/zipkin/util/WingtipsToZipkinSpanConverterDefaultImpl.java
@@ -25,6 +25,7 @@ public class WingtipsToZipkinSpanConverterDefaultImpl implements WingtipsToZipki
 
     @Override
     public zipkin.Span convertWingtipsSpanToZipkinSpan(Span wingtipsSpan, Endpoint zipkinEndpoint, String localComponentNamespace) {
+        String traceId = wingtipsSpan.getTraceId();
         long startEpochMicros = wingtipsSpan.getSpanStartTimeEpochMicros();
         long durationMicros = TimeUnit.NANOSECONDS.toMicros(wingtipsSpan.getDurationNanos());
 
@@ -33,7 +34,8 @@ public class WingtipsToZipkinSpanConverterDefaultImpl implements WingtipsToZipki
             .name(wingtipsSpan.getSpanName())
             .parentId(nullSafeLong(wingtipsSpan.getParentSpanId()))
             .timestamp(startEpochMicros)
-            .traceId(nullSafeLong(wingtipsSpan.getTraceId()))
+            .traceIdHigh(traceId.length() == 32 ? nullSafeLong(traceId, 0) : 0)
+            .traceId(nullSafeLong(traceId))
             .duration(durationMicros)
             .build();
     }
@@ -73,4 +75,10 @@ public class WingtipsToZipkinSpanConverterDefaultImpl implements WingtipsToZipki
         return TraceAndSpanIdGenerator.unsignedLowerHexStringToLong(lowerHexStr);
     }
 
+    protected Long nullSafeLong(String lowerHexStr, int index) {
+        if (lowerHexStr == null)
+            return null;
+
+        return TraceAndSpanIdGenerator.unsignedLowerHexStringToLong(lowerHexStr, index);
+    }
 }


### PR DESCRIPTION
This allows Wingtips to report 128-bit trace IDs to Zipkin, by parsing
this high bits of a 32-character hex-encoded ID.

See https://github.com/openzipkin/b3-propagation/issues/6