### PR TITLE
Disable AsyncContext checks when running in legacy servlet containers

### DIFF
--- a/wingtips-servlet-api/src/main/java/com/nike/wingtips/servlet/RequestTracingFilter.java
+++ b/wingtips-servlet-api/src/main/java/com/nike/wingtips/servlet/RequestTracingFilter.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -37,7 +38,30 @@ import static com.nike.wingtips.util.AsyncWingtipsHelperJava7.unlinkTracingFromC
  */
 @SuppressWarnings("WeakerAccess")
 public class RequestTracingFilter implements Filter {
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(RequestTracingFilter.class);
+
+    protected static boolean containerSupportsAsyncContexts;
+
+    static {
+        containerSupportsAsyncContexts = areAsyncContextsOk(ServletRequest.class);
+    }
+
+    /**
+     * Determines whether the current servlet container supports AsyncContexts.
+     *
+     * @param servletRequestClass ServletRequest class
+     * @return true if servletRequest class supports calls getAsyncContext(), otherwise false
+     */
+    protected static boolean areAsyncContextsOk(Class<?> servletRequestClass) {
+        Method asyncContextMethod = null;
+        try {
+            asyncContextMethod = servletRequestClass.getMethod("getAsyncContext");
+        } catch (Exception ex) {
+            logger.debug("No async context supported on the current container", ex);
+        }
+
+        return asyncContextMethod != null;
+    }
 
     /**
      * This attribute key will be set to a value of true via {@link ServletRequest#setAttribute(String, Object)} the
@@ -164,7 +188,7 @@ public class RequestTracingFilter implements Filter {
             try {
                 filterChain.doFilter(request, response);
             } finally {
-                if (request.isAsyncStarted()) {
+                if (containerSupportsAsyncContexts && request.isAsyncStarted()) {
                     // Async processing was started, so we have to complete it with a listener.
                     request.getAsyncContext().addListener(
                         new WingtipsRequestSpanCompletionAsyncListener(originalRequestTracingState)

--- a/wingtips-servlet-api/src/test/java/com/nike/wingtips/servlet/RequestTracingFilterTest.java
+++ b/wingtips-servlet-api/src/test/java/com/nike/wingtips/servlet/RequestTracingFilterTest.java
@@ -64,6 +64,7 @@ public class RequestTracingFilterTest {
     private AsyncContext listenerCapturingAsyncContext;
     private List<AsyncListener> capturedAsyncListeners;
     private FilterConfig filterConfigMock;
+    private boolean savedContainerSupportsAsyncContexts;
 
     private static final String USER_ID_HEADER_KEY = "userId";
     private static final String ALT_USER_ID_HEADER_KEY = "altUserId";
@@ -122,6 +123,7 @@ public class RequestTracingFilterTest {
         responseMock = mock(HttpServletResponse.class);
         filterChainMock = mock(FilterChain.class);
         spanCapturingFilterChain = new SpanCapturingFilterChain();
+        savedContainerSupportsAsyncContexts = RequestTracingFilter.containerSupportsAsyncContexts;
 
         filterConfigMock = mock(FilterConfig.class);
         doReturn(USER_ID_HEADER_KEYS_INIT_PARAM_VALUE_STRING).when(filterConfigMock).getInitParameter(RequestTracingFilter.USER_ID_HEADER_KEYS_LIST_INIT_PARAM_NAME);
@@ -132,6 +134,8 @@ public class RequestTracingFilterTest {
     @After
     public void afterMethod() {
         resetTracing();
+
+        RequestTracingFilter.containerSupportsAsyncContexts = savedContainerSupportsAsyncContexts;
     }
 
     private void resetTracing() {
@@ -572,6 +576,25 @@ public class RequestTracingFilterTest {
         assertThat(capturedAsyncListeners.get(0)).isInstanceOf(WingtipsRequestSpanCompletionAsyncListener.class);
     }
 
+    @Test
+    public void doFilterInternal_should_not_add_async_listener_when_container_does_not_support_async_contexts(
+    ) throws ServletException, IOException {
+        // given
+        RequestTracingFilter filter = getBasicFilter();
+        setupAsyncContextWorkflow();
+
+        // and
+        RequestTracingFilter.containerSupportsAsyncContexts = false;
+
+        // when
+        filter.doFilterInternal(requestMock, responseMock, spanCapturingFilterChain);
+
+        // then
+        assertThat(spanCapturingFilterChain.capturedSpan).isNotNull();
+        assertThat(spanCapturingFilterChain.capturedSpan.isCompleted()).isTrue();
+        assertThat(capturedAsyncListeners).hasSize(0);
+    }
+
     // VERIFY skipDispatch ==============================
 
     @Test
@@ -620,4 +643,36 @@ public class RequestTracingFilterTest {
         assertThat(result).isEqualTo(expectedResult);
     }
 
+    /**
+     * Dummy class that has a good getAsyncContext function
+     */
+    private static final class GoodFakeServletRequest {
+        public Object getAsyncContext() {
+            return Boolean.TRUE;
+        }
+    }
+
+    @Test
+    public void areAsyncContextsOk_returns_true() throws Exception {
+        // expect
+        boolean result = RequestTracingFilter.areAsyncContextsOk(GoodFakeServletRequest.class);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    /**
+     * Dummy class that does NOT have a getAsyncContext function
+     */
+    private static final class BadFakeServletRequest {
+    }
+
+    @Test
+    public void areAsyncContextsOk_returns_false() throws Exception {
+        // expect
+        boolean result = RequestTracingFilter.areAsyncContextsOk(BadFakeServletRequest.class);
+
+        // then
+        assertThat(result).isFalse();
+    }
 }


### PR DESCRIPTION
Test to see if ServletRequest.getAsyncContext() is supported before calling it.  This prevents NoSuchMethodExceptions from being thrown near the AsyncContext code on pre-Servlet 3.0 containers like Jetty 6.