### PR TITLE
Adding support for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ of using Wingtips that are simple, compact, and straightforward.
 * [Usage in Reactive Asynchronous Nonblocking Scenarios](#async_usage)
 * [Using Distributed Tracing to Help with Debugging Issues/Errors/Problems](#using_dtracing_for_errors)
 * [Custom Annotations](#custom_annotations)
+* [Tags](#tags)
 * [Integrating With Other Distributed Tracing Tools](#integrating_with_other_dtrace_tools)
 * [Sample Applications](#samples)
 * [License](#license)
@@ -417,6 +418,16 @@ That said, it can be extremely helpful in many cases for debugging or error inve
 The Google Dapper paper describes how the Dapper tools allow them to associate arbitrary timestamped notes called "annotations" with any span. Wingtips does not currently support annotations, but the most important use case for annotations - knowing when a client sent a request vs when the server received it (and vice versa on the response) - is simulated in Wingtips by surrounding a client request with a sub-span and making sure the called service creates an overall request span for itself as well. This technique is described in the "[using sub-spans to surround downstream calls](#sub_spans_for_downstream_calls)" section. Even if Wingtips supported Dapper-style annotations this technique would likely still be required unless you instrumented your HTTP and/or RPC caller libraries at a very low level - a task that made sense for Google with their relatively homogenous ecosystem and developer resources, but not necessarily realistic for wider audiences.
 
 Arbitrary application-specific annotations could be a useful addition however, so this feature may be added in the future. Until then you can output log messages tagged with tracing and timestamp information to approximate the functionality.
+
+<a name="tags"></a>
+## Tags
+Tags allow for key-value pairs to be associated with a span as metadata, often useful for filtering or grouping trace information.  For example, say you've instrumented retry logic. It may be desireable to be able to distinguish between a span/trace that contains retries and those that didn't.  Or you may want to tag your spans based on an attribute of the request, like user type or an authenticated flag. 
+
+```
+Tracer.getInstance().getCurrentSpan().putTag("UserType", user.getType());
+```
+
+They value of the tag is mutable and both key and value are stored as strings.  Calling `putTag(...)` will replace any existing values for the key, or add the new key value pair if one doesn't exist. 
 
 <a name="integrating_with_other_dtrace_tools"></a>
 ## Integrating With Other Distributed Tracing Tools

--- a/wingtips-core/src/main/java/com/nike/wingtips/util/SpanParser.java
+++ b/wingtips-core/src/main/java/com/nike/wingtips/util/SpanParser.java
@@ -1,0 +1,308 @@
+package com.nike.wingtips.util;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.nike.wingtips.Span;
+import com.nike.wingtips.Span.SpanPurpose;
+
+public class SpanParser {
+
+	private static final Logger logger = LoggerFactory.getLogger(SpanParser.class);
+	
+	/** The name of the trace ID field when serializing/deserializing to/from JSON (see {@link #toJSON()} and {@link #fromJSON(String)}). Corresponds to {@link #getTraceId()}. */
+    public static final String TRACE_ID_FIELD = "traceId";
+    /** The name of the parent span ID field when serializing/deserializing to/from JSON (see {@link #toJSON()} and {@link #fromJSON(String)}). Corresponds to {@link #getParentSpanId()}. */
+    public static final String PARENT_SPAN_ID_FIELD = "parentSpanId";
+    /** The name of the span ID field when serializing/deserializing to/from JSON (see {@link #toJSON()} and {@link #fromJSON(String)}). Corresponds to {@link #getSpanId()}. */
+    public static final String SPAN_ID_FIELD = "spanId";
+    /** The name of the span name field when serializing/deserializing to/from JSON (see {@link #toJSON()} and {@link #fromJSON(String)}). Corresponds to {@link #getSpanName()}. */
+    public static final String SPAN_NAME_FIELD = "spanName";
+    /** The name of the sampleable field when serializing/deserializing to/from JSON (see {@link #toJSON()} and {@link #fromJSON(String)}). Corresponds to {@link #isSampleable()}. */
+    public static final String SAMPLEABLE_FIELD = "sampleable";
+    /** The name of the user ID field when serializing/deserializing to/from JSON (see {@link #toJSON()} and {@link #fromJSON(String)}). Corresponds to {@link #getUserId()}. */
+    public static final String USER_ID_FIELD = "userId";
+    /** The name of the span purpose field when serializing to JSON (see {@link #toJSON()}. Corresponds to {@link #getSpanPurpose()}. */
+    public static final String SPAN_PURPOSE_FIELD = "spanPurpose";
+    /** The name of the start-time-in-epoch-micros field when serializing/deserializing to/from JSON (see {@link #toJSON()} and {@link #fromJSON(String)}). Corresponds to {@link #getSpanStartTimeNanos()}. */
+    public static final String START_TIME_EPOCH_MICROS_FIELD = "startTimeEpochMicros";
+    /** The name of the duration-in-nanoseconds field when serializing to JSON (see {@link #toJSON()}. Corresponds to {@link #getDurationNanos()}. */
+    public static final String DURATION_NANOS_FIELD = "durationNanos";
+    /** The name of the span tags field when serializing to JSON (see {@link #toJSON()}. Corresponds to {@link #getTags()}. */
+    public static final String TAGS_FIELD = "tags";
+    
+	public static Span parseKeyValueFormat(String input) {
+		return null;
+	}
+	
+	public static String convertSpanToKeyValueFormat(Span span) {
+		 StringBuilder builder = new StringBuilder();
+
+        builder.append(TRACE_ID_FIELD).append("=").append(span.getTraceId());
+        builder.append(",").append(PARENT_SPAN_ID_FIELD).append("=").append(span.getParentSpanId());
+        builder.append(",").append(SPAN_ID_FIELD).append("=").append(span.getSpanId());
+        builder.append(",").append(SPAN_NAME_FIELD).append("=").append(span.getSpanName());
+        builder.append(",").append(SAMPLEABLE_FIELD).append("=").append(span.isSampleable());
+        builder.append(",").append(USER_ID_FIELD).append("=").append(span.getUserId());
+        builder.append(",").append(SPAN_PURPOSE_FIELD).append("=").append(span.getSpanPurpose().name());
+        builder.append(",").append(START_TIME_EPOCH_MICROS_FIELD).append("=").append(span.getSpanStartTimeEpochMicros());
+        if (span.isCompleted()) {
+            builder.append(",").append(DURATION_NANOS_FIELD).append("=").append(span.getDurationNanos());
+        }
+        if (span.getTags() != null && !span.getTags().isEmpty()) 
+        		builder.append(",").append(TAGS_FIELD).append("=[").append(convertMapToKeyValueString(span.getTags())).append("]");
+        
+        return builder.toString();
+	}
+	
+	/**
+     * Calculates and returns the JSON representation of this span instance. We build this manually ourselves to avoid pulling in an extra dependency
+     * (e.g. Jackson) just for building a simple JSON string.
+     */
+	public static String convertSpanToJSON(Span span) {
+		StringBuilder builder = new StringBuilder();
+
+        builder.append("{\"").append(TRACE_ID_FIELD).append("\":\"").append(span.getTraceId());
+        builder.append("\",\"").append(PARENT_SPAN_ID_FIELD).append("\":\"").append(span.getParentSpanId());
+        builder.append("\",\"").append(SPAN_ID_FIELD).append("\":\"").append(span.getSpanId());
+        builder.append("\",\"").append(SPAN_NAME_FIELD).append("\":\"").append(span.getSpanName());
+        builder.append("\",\"").append(SAMPLEABLE_FIELD).append("\":\"").append(span.isSampleable());
+        builder.append("\",\"").append(USER_ID_FIELD).append("\":\"").append(span.getUserId());
+        builder.append("\",\"").append(SPAN_PURPOSE_FIELD).append("\":\"").append(span.getSpanPurpose().name());
+        builder.append("\",\"").append(START_TIME_EPOCH_MICROS_FIELD).append("\":\"").append(span.getSpanStartTimeEpochMicros());
+        if (span.isCompleted()) {
+            builder.append("\",\"").append(DURATION_NANOS_FIELD).append("\":\"").append(span.getDurationNanos());
+        }
+        builder.append("\"");
+        if(!span.getTags().isEmpty()) {
+        		// Create nested json for the tags
+        		builder.append(",\"").append(TAGS_FIELD).append("\":{");
+        		builder.append(convertMapToJsonValues(span.getTags())).append("}");
+        } 
+        builder.append("}");
+
+        return builder.toString();
+	}
+    
+    /**
+     * @return The {@link Span} represented by the given key/value string, or null if a proper span could not be deserialized from the given string.
+     *          <b>WARNING:</b> This method assumes the string you're trying to deserialize originally came from
+     *          {@link #toKeyValueString()}. This assumption allows it to be as fast as possible, not worry about syntactically-correct-but-annoying-to-deal-with whitespace,
+     *          not have to use a third party utility, etc.
+     */
+    public static Span fromKeyValueString(String keyValueStr) {
+        try {
+        		Map<String,String> map;
+
+        		if(keyValueStringHasTagsPresent(keyValueStr)) {
+        			//Pull tags into their own map
+        			Map<String,String> tags = parseTagsFromFullKeyValueString(keyValueStr);
+        			//Strip out the tags
+        			String keyValueStrWithoutTags = removeTagsFromKeyValueString(keyValueStr);
+        			//Parse the remaining keyValue pairs
+        			map = getMapFromKeyValueString(keyValueStrWithoutTags);
+        			return fromKeyValueMap(map, tags);
+            } else {
+            		map = getMapFromKeyValueString(keyValueStr);
+            		return fromKeyValueMap(map, null);
+            }
+            
+        } catch (Exception e) {
+            logger.error("Error extracting Span from key/value string. Defaulting to null. bad_span_key_value_string={}", keyValueStr, e);
+            return null;
+        }
+    }
+
+    private static boolean keyValueStringHasTagsPresent(String keyValueStr) {
+    		return keyValueStr.contains(TAGS_FIELD + "=[");
+    }
+    private static Map<String,String> parseTagsFromFullKeyValueString(String keyValueStr) {
+    		String tagsKeyValueString = parseTagKeyValueString(keyValueStr);
+    		return getMapFromKeyValueString(tagsKeyValueString);
+    }
+    
+    /** Returns only the key value pairs, not the tags=[   and closing   ]  **/
+    protected static String parseTagKeyValueString(String keyValueStr) {
+    		// find where it starts and then move forward the length of the pattern
+		int tagStart = keyValueStr.indexOf( TAGS_FIELD+"=[" ) + TAGS_FIELD.length() + 2;
+		int tagEnd = keyValueStr.indexOf("]");
+		String tagsOnly = keyValueStr.substring(tagStart, tagEnd);
+		return tagsOnly;
+    }
+    
+    private static String removeTagsFromKeyValueString(String keyValueStrWithTags) {
+    		String tagStringToRemove = "," + TAGS_FIELD + "=[" + parseTagKeyValueString(keyValueStrWithTags) + "]";
+    		return keyValueStrWithTags.replace(tagStringToRemove, "");
+    }
+    
+    /** 
+     * @param keyValueStr Should be in format {@code key=value,key2=value2}
+     */
+    private static Map<String,String> getMapFromKeyValueString(String keyValueStr) {
+    		// Create a map of keys to values.
+        Map<String, String> map = new HashMap<>();
+
+        // Split on the commas that separate the key/value pairs.
+        String[] fieldPairs = keyValueStr.split(",");
+        for (String fieldPair : fieldPairs) {
+            // Split again on the equals character that separate the field's key from its value.
+            String[] keyVal = fieldPair.split("=");
+            map.put(keyVal[0], keyVal[1]);
+        }
+        return map;
+    }
+    /**
+     * @return The {@link Span} represented by the given JSON string, or null if a proper span could not be deserialized from the given string.
+     *          <b>WARNING:</b> This method assumes the JSON you're trying to deserialize originally came from {@link #toJSON()}.
+     *          This assumption allows it to be as fast as possible, not have to check for malformed JSON, not worry about syntactically-correct-but-annoying-to-deal-with whitespace,
+     *          not have to use a third party utility like Jackson, etc.
+     */
+    public static Span fromJSON(String json) {
+        try {
+        		Map<String,String> tags = null;
+        		Map<String,String> map;
+            if(json.contains("\""+TAGS_FIELD+"\":{")) {
+            		tags = parseTagsFromNestedJson(json);
+            		String jsonWithoutNestedTags = removeTagsFromJson(json);
+            		map = parseSingleKeyValueJson(jsonWithoutNestedTags); 
+            } else {
+            		map = parseSingleKeyValueJson(json);
+            }
+
+            return fromKeyValueMap(map, tags);
+        } catch (Exception e) {
+            logger.error("Error extracting Span from JSON. Defaulting to null. bad_span_json={}", json, e);
+            return null;
+        }
+    }
+    
+    protected static Map<String,String> parseTagsFromNestedJson(String jsonWithNestedTagValues) {
+    		String tagsOnly = parseNestedTagJson(jsonWithNestedTagValues);
+		return parseSingleKeyValueJson(tagsOnly);
+    }
+    
+    /** @return the inner set of tag pairs with surrounding { }  **/
+    protected static String parseNestedTagJson(String jsonWithNestedTagValues) {
+    		int tagStart = jsonWithNestedTagValues.indexOf(TAGS_FIELD + "\":") + TAGS_FIELD.length() + 2;
+		int tagEnd = jsonWithNestedTagValues.indexOf("}") + 1;
+		String tagsOnly = jsonWithNestedTagValues.substring(tagStart, tagEnd);
+		return tagsOnly;
+    }
+    
+    protected static String removeTagsFromJson(String jsonWithNestedValues) {
+    		String fullTagJson = ",\"" + TAGS_FIELD + "\":" + parseNestedTagJson(jsonWithNestedValues);
+    		return jsonWithNestedValues.replace(fullTagJson, "");
+    }
+    
+    protected static String convertMapToJsonValues(Map<String,String> map) {
+    		StringBuilder builder = new StringBuilder();
+    		Iterator<Map.Entry<String, String>> it = map.entrySet().iterator();
+	    while (it.hasNext()) {
+	        Map.Entry<String,String> tag = (Map.Entry<String,String>)it.next();
+			builder.append("\"").append(tag.getKey()).append("\":\"").append(tag.getValue()).append("\"");
+			 if(it.hasNext())
+	        		builder.append(",");
+		}
+	    return builder.toString();
+    }
+    
+    /**
+     * This method expects no nested JSON values. For example {tags: {tag1:val1,tag2:val2}} will throw an exception.
+     * @param json
+     * @return
+     */
+    private static Map<String,String> parseSingleKeyValueJson(String json) {
+    		// Create a map of JSON field keys to values.
+        Map<String, String> map = new HashMap<>();
+
+        // Strip off the {" and "} at the beginning/end.
+        String innerJsonCore = json.substring(2, json.length() - 2);
+        // Split on the doublequotes-comma-doublequotes that separate the fields.
+        String[] fieldPairs = innerJsonCore.split("\",\"");
+        for (String fieldPair : fieldPairs) {
+            // Split again on the doublequotes-colon-doublequotes that separate the field's key from its value. At this point all double-quotes have been stripped off
+            // and we can just map the key to the value.
+            String[] keyVal = fieldPair.split("\":\"");
+            map.put(keyVal[0], keyVal[1]);
+        }
+        return map;
+    }
+
+    private static Span fromKeyValueMap(Map<String, String> map, Map<String,String> tags) {
+        // Use the map to get the field values for the span.
+        String traceId = nullSafeGetString(map, TRACE_ID_FIELD);
+        String spanId = nullSafeGetString(map, SPAN_ID_FIELD);
+        String parentSpanId = nullSafeGetString(map, PARENT_SPAN_ID_FIELD);
+        String spanName = nullSafeGetString(map, SPAN_NAME_FIELD);
+        Boolean sampleable = nullSafeGetBoolean(map, SAMPLEABLE_FIELD);
+        if (sampleable == null)
+            throw new IllegalStateException("Unable to parse " + SAMPLEABLE_FIELD + " from JSON");
+        String userId = nullSafeGetString(map, USER_ID_FIELD);
+        Long startTimeEpochMicros = nullSafeGetLong(map, START_TIME_EPOCH_MICROS_FIELD);
+        if (startTimeEpochMicros == null)
+            throw new IllegalStateException("Unable to parse " + START_TIME_EPOCH_MICROS_FIELD + " from JSON");
+        Long durationNanos = nullSafeGetLong(map, DURATION_NANOS_FIELD);
+        SpanPurpose spanPurpose = nullSafeGetSpanPurpose(map, SPAN_PURPOSE_FIELD);
+        return new Span(traceId, parentSpanId, spanId, spanName, sampleable, userId, spanPurpose, startTimeEpochMicros, null, durationNanos, tags);
+    }
+    
+    /**
+     * @todo Could have a ConcurrentModificationException if tags are added while iterating through
+     */
+    static String convertMapToKeyValueString(Map<String, String> map) {
+    		StringBuilder builder = new StringBuilder();
+		if(map != null && map.size() > 0) {
+			Iterator<Map.Entry<String, String>> it = map.entrySet().iterator();
+		    while (it.hasNext()) {
+		        Map.Entry<String,String> pair = (Map.Entry<String,String>)it.next();
+		        builder.append(pair.getKey()).append("=").append(pair.getValue());
+		        if(it.hasNext())
+		        		builder.append(",");
+		    }
+		} 
+
+		return builder.toString();
+    }
+     
+    private static String nullSafeGetString(Map<String, String> map, String key) {
+        String value = map.get(key);
+        if (value == null || value.equals("null"))
+            return null;
+
+        return value;
+    }
+
+    private static Long nullSafeGetLong(Map<String, String> map, String key) {
+        String value = nullSafeGetString(map, key);
+        if (value == null)
+            return null;
+
+        return Long.parseLong(value);
+    }
+
+    private static Boolean nullSafeGetBoolean(Map<String, String> map, String key) {
+        String value = nullSafeGetString(map, key);
+        if (value == null)
+            return null;
+
+        return Boolean.parseBoolean(value);
+    }
+
+    private static SpanPurpose nullSafeGetSpanPurpose(Map<String, String> map, String key) {
+        String value = nullSafeGetString(map, key);
+        if (value == null)
+            return null;
+
+        try {
+            return SpanPurpose.valueOf(value);
+        }
+        catch(Exception ex) {
+            logger.warn("Unable to parse \"{}\" to a SpanPurpose enum. Received exception: {}", value, ex.toString());
+            return null;
+        }
+    }
+}

--- a/wingtips-core/src/test/java/com/nike/wingtips/TestSpanCompleter.java
+++ b/wingtips-core/src/test/java/com/nike/wingtips/TestSpanCompleter.java
@@ -1,0 +1,15 @@
+package com.nike.wingtips;
+
+public class TestSpanCompleter {
+
+	/**
+	 * The {@code Span.complete()} method is package protected and we'd like to keep it that way.  For testing
+	 * we need a way to create spans in a completed state so this class is a bridge between the packages.  
+	 * 
+	 * @see test use cases from {@code com.nike.wingtips.util.SpanParserTest}
+	 * @param span
+	 */
+	public static void completeSpan(Span span) {
+		span.complete();
+	}
+}

--- a/wingtips-core/src/test/java/com/nike/wingtips/util/SpanParserTest.java
+++ b/wingtips-core/src/test/java/com/nike/wingtips/util/SpanParserTest.java
@@ -1,0 +1,755 @@
+package com.nike.wingtips.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.assertj.core.data.Offset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.internal.util.reflection.Whitebox;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nike.wingtips.Span;
+import com.nike.wingtips.Span.SpanPurpose;
+import com.nike.wingtips.TestSpanCompleter;
+import com.nike.wingtips.TraceAndSpanIdGenerator;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+
+import com.nike.wingtips.Tracer;
+
+@RunWith(DataProviderRunner.class)
+public class SpanParserTest {
+
+	private String traceId = TraceAndSpanIdGenerator.generateId();
+    private String spanId = TraceAndSpanIdGenerator.generateId();
+    private String parentSpanId = TraceAndSpanIdGenerator.generateId();
+    private String spanName = "spanName-" + UUID.randomUUID().toString();
+    private String userId = "userId-" + UUID.randomUUID().toString();
+    private SpanPurpose spanPurpose = SpanPurpose.SERVER;
+    private boolean sampleableForFullyCompleteSpan = false;
+    private long startTimeEpochMicrosForFullyCompleteSpan = 42;
+    private long startTimeNanosForFullyCompleteSpan = calculateNanoStartTimeFromSpecifiedEpochMicrosStartTime(
+        startTimeEpochMicrosForFullyCompleteSpan,
+        TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis()),
+        System.nanoTime());
+    private long durationNanosForFullyCompletedSpan = 424242;
+    private SpanPurpose spanPurposeForFullyCompletedSpan = SpanPurpose.SERVER;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    private enum TAG_SET {
+    		NULL {
+    			public Map<String,String> getTags() {
+    				return null;
+    			}
+    		},
+    		SINGLE_VALUE {
+    			public Map<String,String> getTags() {
+    				return Collections.singletonMap("Key", "Value");
+    			}
+    		},
+    		MULTIPLE_VALUES {
+    			public Map<String,String> getTags() {
+    				Map<String, String> tags = new HashMap<String,String>();
+    				tags.put("key", "value");
+    				tags.put("color", "blue");
+    				tags.put("day", "today");
+    				return tags;
+    			}
+    		},
+    		SPECIAL_CHARS {
+    			public Map<String,String> getTags() {
+    				Map<String, String> tags = new HashMap<String,String>();
+    				tags.put("key+s", "value");
+    				tags.put("c0!0$%^&", "$%^&(*&^&*<>?");
+    				return tags;
+    			}
+    		};
+    		
+    		public abstract Map<String,String> getTags();
+    }
+    
+    private Span createFilledOutSpan(boolean completed) {
+    		return createFilledOutSpan(completed, TAG_SET.SINGLE_VALUE.getTags());
+    }
+    
+    private Span createFilledOutSpan(boolean completed, Map<String, String> tags) {
+        Long durationNanos = (completed) ? durationNanosForFullyCompletedSpan : null;
+        return new Span(traceId, parentSpanId, spanId, spanName, sampleableForFullyCompleteSpan, userId,
+                        spanPurposeForFullyCompletedSpan, startTimeEpochMicrosForFullyCompleteSpan, startTimeNanosForFullyCompleteSpan, durationNanos, tags);
+    }
+    
+    private void verifySpanDeepEquals(Span span1, Span span2, boolean allowStartTimeNanosFudgeFactor) {
+        assertThat(span1.getSpanStartTimeEpochMicros()).isEqualTo(span2.getSpanStartTimeEpochMicros());
+        if (allowStartTimeNanosFudgeFactor)
+            assertThat(span1.getSpanStartTimeNanos()).isCloseTo(span2.getSpanStartTimeNanos(), Offset.offset(TimeUnit.MILLISECONDS.toNanos(1)));
+        else
+            assertThat(span1.getSpanStartTimeNanos()).isEqualTo(span2.getSpanStartTimeNanos());
+        assertThat(span1.isCompleted()).isEqualTo(span2.isCompleted());
+        assertThat(span1.getTraceId()).isEqualTo(span2.getTraceId());
+        assertThat(span1.getSpanId()).isEqualTo(span2.getSpanId());
+        assertThat(span1.getParentSpanId()).isEqualTo(span2.getParentSpanId());
+        assertThat(span1.getSpanName()).isEqualTo(span2.getSpanName());
+        assertThat(span1.isSampleable()).isEqualTo(span2.isSampleable());
+        assertThat(span1.getUserId()).isEqualTo(span2.getUserId());
+        assertThat(span1.getDurationNanos()).isEqualTo(span2.getDurationNanos());
+        assertThat(span1.getSpanPurpose()).isEqualTo(span2.getSpanPurpose());
+        assertThat(span1.getTags()).isEqualTo(span2.getTags());
+    }
+    
+    private long calculateNanoStartTimeFromSpecifiedEpochMicrosStartTime(long epochMicrosStartTime, long currentEpochMicros, long currentNanoTime) {
+        long currentDurationMicros = currentEpochMicros - epochMicrosStartTime;
+        long nanoStartTimeOffset = TimeUnit.MICROSECONDS.toNanos(currentDurationMicros);
+        return currentNanoTime - nanoStartTimeOffset;
+    }
+    
+	 /**
+     * @return The string "null" if obj is null (in order to match how Span.toJson() functions), otherwise
+     * String.valueOf(obj).
+     */
+    private String nullSafeStringValueOf(Object obj) {
+        if (obj == null) {
+            return "null";
+        }
+
+        return String.valueOf(obj);
+    }
+    
+	private void verifySpanEqualsDeserializedValues(Span span, Map<String, String> deserializedValues) {
+        assertThat(nullSafeStringValueOf(span.getSpanStartTimeEpochMicros())).isEqualTo(deserializedValues.get(SpanParser.START_TIME_EPOCH_MICROS_FIELD));
+        assertThat(span.isCompleted()).isEqualTo(deserializedValues.containsKey(SpanParser.DURATION_NANOS_FIELD));
+        assertThat(nullSafeStringValueOf(span.getTraceId())).isEqualTo(deserializedValues.get(SpanParser.TRACE_ID_FIELD));
+        assertThat(nullSafeStringValueOf(span.getSpanId())).isEqualTo(deserializedValues.get(SpanParser.SPAN_ID_FIELD));
+        assertThat(nullSafeStringValueOf(span.getParentSpanId())).isEqualTo(deserializedValues.get(SpanParser.PARENT_SPAN_ID_FIELD));
+        assertThat(nullSafeStringValueOf(span.getSpanName())).isEqualTo(deserializedValues.get(SpanParser.SPAN_NAME_FIELD));
+        assertThat(nullSafeStringValueOf(span.isSampleable())).isEqualTo(deserializedValues.get(SpanParser.SAMPLEABLE_FIELD));
+        assertThat(nullSafeStringValueOf(span.getUserId())).isEqualTo(deserializedValues.get(SpanParser.USER_ID_FIELD));
+        assertThat(nullSafeStringValueOf(span.getDurationNanos())).isEqualTo(nullSafeStringValueOf(deserializedValues.get(SpanParser.DURATION_NANOS_FIELD)));
+        assertThat(nullSafeStringValueOf(span.getSpanPurpose())).isEqualTo(nullSafeStringValueOf(deserializedValues.get(SpanParser.SPAN_PURPOSE_FIELD)));
+    }
+	
+	private void verifySpanTagsEqualDeserializedValues(Map<String,String> tags, Map<String,String> deserializedTags) {
+		assertThat(twoMapsAreEqual(tags, deserializedTags));
+	}
+	
+	protected boolean twoMapsAreEqual(Map<String, String> one, Map<String,String> two) {
+		if (one.size() != two.size()) 
+			return false;
+		return verifyMapContainsIdenticalEntries(one,two) &&
+			   verifyMapContainsIdenticalEntries(two,one);
+	}
+	
+	protected boolean verifyMapContainsIdenticalEntries(Map<String,String> mapOne, Map<String,String> mapTwo) {
+		for(Map.Entry<String, String> entry : mapTwo.entrySet()) {
+			if (!mapOne.containsKey(entry.getKey())) 
+				return false;
+			String mapOneValue = mapOne.get(entry.getKey());
+			String mapTwoValue = entry.getValue();
+			if (! mapOneValue.equals(mapTwoValue))
+				return false;
+		}
+		return true;
+	}
+	
+	protected void completeSpan(Span span) {
+		TestSpanCompleter.completeSpan(span);
+	}
+	
+	/** @todo Create a TypeReference that knows how to parse this JSON **/
+	@DataProvider( value = {
+        "NULL",
+        "SINGLE_VALUE",
+        "MULTIPLE_VALUES",
+        "SPECIAL_CHARS"
+    })
+	@Test
+    public void toJson_should_function_properly_when_there_are_no_null_values(TAG_SET tags) throws IOException {
+        // given: valid span without any null values, span completed (so that end time is not null) and JSON string from Span.toJson()
+        Span validSpan = createFilledOutSpan(true, tags.getTags());
+        assertThat(validSpan.getTraceId()).isNotEmpty();
+        assertThat(validSpan.getUserId()).isNotEmpty();
+        assertThat(validSpan.getParentSpanId()).isNotEmpty();
+        assertThat(validSpan.getSpanName()).isNotEmpty();
+        assertThat(validSpan.getSpanId()).isNotEmpty();
+        assertThat(validSpan.getDurationNanos()).isNotNull();
+        assertThat(validSpan.isCompleted()).isTrue();
+        assertThat(validSpan.getSpanPurpose()).isNotNull();
+        String json = validSpan.toJSON();
+        
+        if(tags.getTags() == null || tags.getTags().isEmpty()) {
+        		Map<String, String> spanValuesFromJackson = objectMapper.readValue(json, new TypeReference<Map<String, String>>() {});
+        		verifySpanEqualsDeserializedValues(validSpan, spanValuesFromJackson);
+        } else {
+        		//Parse the tags separately from the rest of the json
+        		String jsonWithoutNestedTags = SpanParser.removeTagsFromJson(json);
+        		String tagJson = SpanParser.parseNestedTagJson(json);
+      
+        		// when: jackson is used to deserialize that JSON
+        		Map<String, String> spanValuesFromJackson = objectMapper.readValue(jsonWithoutNestedTags, new TypeReference<Map<String, String>>() {});
+        		Map<String, String> tagsFromJackson = objectMapper.readValue(tagJson, new TypeReference<Map<String, String>>() {});
+      
+        		// then: the original span context and jackson's span context values should be exactly the same
+        		verifySpanEqualsDeserializedValues(validSpan, spanValuesFromJackson);
+        		verifySpanTagsEqualDeserializedValues(validSpan.getTags(), tagsFromJackson);
+        }
+    }
+
+    @Test
+    public void toJson_should_function_properly_when_there_are_null_values() throws IOException {
+        // given: valid span with null values and JSON string from Span.toJson()
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, null).build();
+        assertThat(validSpan.getParentSpanId()).isNull();
+        assertThat(validSpan.getUserId()).isNull();
+        String json = validSpan.toJSON();
+
+        // when: jackson is used to deserialize that JSON
+        Map<String, String> spanValuesFromJackson = objectMapper.readValue(json, new TypeReference<Map<String, String>>() {});
+
+        // then: the original span context and jackson's span context values should be exactly the same
+        verifySpanEqualsDeserializedValues(validSpan, spanValuesFromJackson);
+    }
+
+    @Test
+    public void toJson_should_function_properly_for_non_completed_spans() throws IOException {
+        // given: valid span and JSON string from Span.toJson()
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, spanPurpose).build();
+        String json = validSpan.toJSON();
+        assertThat(validSpan.isCompleted()).isFalse();
+        assertThat(validSpan.getDurationNanos()).isNull();
+
+        // when: jackson is used to deserialize that JSON
+        Map<String, String> spanValuesFromJackson = objectMapper.readValue(json, new TypeReference<Map<String, String>>() {});
+
+        // then: the original span and jackson's span values should be exactly the same
+        verifySpanEqualsDeserializedValues(validSpan, spanValuesFromJackson);
+    }
+
+    @Test
+    public void toJson_should_function_properly_for_completed_spans() throws IOException {
+        // given: valid span and completed, and JSON string from Span.toJson()
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, spanPurpose).build();
+        completeSpan(validSpan);
+        assertThat(validSpan.isCompleted()).isTrue();
+        assertThat(validSpan.getDurationNanos()).isNotNull();
+        String json = validSpan.toJSON();
+
+        // when: jackson is used to deserialize that JSON
+        Map<String, String> spanValuesFromJackson = objectMapper.readValue(json, new TypeReference<Map<String, String>>() {});
+
+        // then: the original span and jackson's span values should be exactly the same
+        verifySpanEqualsDeserializedValues(validSpan, spanValuesFromJackson);
+    }
+
+    @Test
+    public void toJson_should_use_cached_json() {
+        // given
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, spanPurpose).build();
+        String uuidString = UUID.randomUUID().toString();
+        Whitebox.setInternalState(validSpan, "cachedJsonRepresentation", uuidString);
+
+        // when
+        String toJsonResult = validSpan.toJSON();
+
+        // then
+        assertThat(toJsonResult).isEqualTo(uuidString);
+    }
+    
+//    @Test
+//    public void toJson_should_function_properly_with_no_tags() throws IOException {
+//        // given: valid span with null values and JSON string from Span.toJson()
+//        Span validSpan = Span.generateRootSpanForNewTrace(spanName, null).build();
+//        assertThat(validSpan.getTags()).isEmpty();
+//        
+//        String json = validSpan.toJSON();
+//
+//        // when: jackson is used to deserialize that JSON
+//        Map<String, String> spanValuesFromJackson = objectMapper.readValue(json, new TypeReference<Map<String, String>>() {});
+//
+//        // then: the original span context and jackson's span context values should be exactly the same
+//        verifySpanEqualsDeserializedValues(validSpan, spanValuesFromJackson);
+//    }
+
+//    @Test
+//    public void toJson_should_function_properly_with_one_tag() throws IOException {
+//        // given: valid span with null values and JSON string from Span.toJson()
+//        Span validSpan = Span.generateRootSpanForNewTrace(spanName, null).build();
+//        validSpan.addTag("Key", "value");
+//        assertThat(validSpan.getTags()).isNotEmpty();
+//        
+//        String json = validSpan.toJSON();
+//
+//        // when: jackson is used to deserialize that JSON
+//        Map<String, String> spanValuesFromJackson = objectMapper.readValue(json, new TypeReference<Map<String, String>>() {});
+//
+//        // then: the original span context and jackson's span context values should be exactly the same
+//        verifySpanEqualsDeserializedValues(validSpan, spanValuesFromJackson);
+//    }
+//    
+//    @Test
+//    public void toJson_should_function_properly_with_multiple_tags() throws IOException {
+//        // given: valid span with null values and JSON string from Span.toJson()
+//        Span validSpan = Span.generateRootSpanForNewTrace(spanName, null).build();
+//        validSpan.addTag("Key", "value");
+//        validSpan.addTag("Key2", "value2");
+//        assertThat(validSpan.getTags()).isNotEmpty();
+//        
+//        String json = validSpan.toJSON();
+//
+//        // when: jackson is used to deserialize that JSON
+//        Map<String, String> spanValuesFromJackson = objectMapper.readValue(json, new TypeReference<Map<String, String>>() {});
+//
+//        // then: the original span context and jackson's span context values should be exactly the same
+//        verifySpanEqualsDeserializedValues(validSpan, spanValuesFromJackson);
+//    }
+//    
+//    @Test
+//    public void toJson_should_function_properly_with_special_chars_in_tag() throws IOException {
+//        // given: valid span with null values and JSON string from Span.toJson()
+//        Span validSpan = Span.generateRootSpanForNewTrace(spanName, null).build();
+//        validSpan.addTag("Key-a-1!|/!@>#$%%^&*()", "v@l|>u$|");
+//        
+//        assertThat(validSpan.getTags()).isNotEmpty();
+//        
+//        String json = validSpan.toJSON();
+//
+//        String jsonWithoutNestedTags = SpanParser.removeNestedTagsJson(json);
+//        String tagJson = SpanParser.parseNestedTagJson(json);
+//        
+//        // when: jackson is used to deserialize that JSON
+//        Map<String, String> spanValuesFromJackson = objectMapper.readValue(jsonWithoutNestedTags, new TypeReference<Map<String, String>>() {});
+//        Map<String, String> tagsFromJackson = objectMapper.readValue(tagJson, new TypeReference<Map<String, String>>() {});
+//        
+//        // then: the original span context and jackson's span context values should be exactly the same
+//        verifySpanEqualsDeserializedValues(validSpan, spanValuesFromJackson);
+//        verifySpanTagsEqualDeserializedValues(validSpan.getTags(), tagsFromJackson);
+//    }
+    
+    @Test
+    public void complete_should_reset_cached_json() throws IOException {
+        // given
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, spanPurpose).build();
+        String uuidString = UUID.randomUUID().toString();
+        Whitebox.setInternalState(validSpan, "cachedJsonRepresentation", uuidString);
+
+        // when
+        String beforeCompleteJson = validSpan.toJSON();
+        completeSpan(validSpan);
+
+        // then
+        String afterCompleteJson = validSpan.toJSON();
+        assertThat(afterCompleteJson).isNotEqualTo(beforeCompleteJson);
+        assertThat(afterCompleteJson).isNotEqualTo(uuidString);
+        Map<String, String> spanValuesFromJackson = objectMapper.readValue(afterCompleteJson, new TypeReference<Map<String, String>>() { });
+        verifySpanEqualsDeserializedValues(validSpan, spanValuesFromJackson);
+    }
+
+    @DataProvider( value = {
+            "NULL",
+            "SINGLE_VALUE",
+            "MULTIPLE_VALUES",
+            "SPECIAL_CHARS"
+        })
+    @Test
+    public void fromJson_should_function_properly_when_there_are_no_null_values(TAG_SET tags) {
+        // given: valid span without any null values, completed (so that end time is not null) and JSON string from Span.toJson()
+        Span validSpan = createFilledOutSpan(true, tags.getTags());
+        assertThat(validSpan).isNotNull();
+        assertThat(validSpan.getTraceId()).isNotNull();
+        assertThat(validSpan.getUserId()).isNotNull();
+        assertThat(validSpan.getParentSpanId()).isNotNull();
+        assertThat(validSpan.getSpanName()).isNotNull();
+        assertThat(validSpan.getSpanId()).isNotNull();
+        assertThat(validSpan.getDurationNanos()).isNotNull();
+        assertThat(validSpan.isCompleted()).isTrue();
+        assertThat(validSpan.getSpanPurpose()).isNotNull();
+        String json = validSpan.toJSON();
+
+        // when: fromJson is called
+        Span spanFromJson = SpanParser.fromJSON(json);
+
+        // then: the original span and the fromJson() span values should be exactly the same
+        verifySpanDeepEquals(validSpan, spanFromJson, true);
+    }
+
+    @Test
+    public void fromJson_should_function_properly_when_there_are_null_values() throws IOException {
+        // given: valid span with null values and JSON string from Span.toJson()
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, null).build();
+        assertThat(validSpan.getParentSpanId()).isNull();
+        assertThat(validSpan.getUserId()).isNull();
+        assertThat(validSpan.getDurationNanos()).isNull();
+        String json = validSpan.toJSON();
+
+        // when: fromJson is called
+        Span spanFromJson = SpanParser.fromJSON(json);
+
+        // then: the original span and the fromJson() span values should be exactly the same
+        verifySpanDeepEquals(validSpan, spanFromJson, true);
+    }
+
+    @Test
+    public void fromJson_should_function_properly_for_non_completed_spans() throws IOException {
+        // given: valid, non-completed span and JSON string from Span.toJson()
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, spanPurpose).build();
+        String json = validSpan.toJSON();
+        assertThat(validSpan.isCompleted()).isFalse();
+
+        // when: fromJson is called
+        Span spanFromJson = SpanParser.fromJSON(json);
+
+        // then: the original span and the fromJson() span values should be exactly the same
+        verifySpanDeepEquals(validSpan, spanFromJson, true);
+    }
+
+        @Test
+    public void fromJson_should_function_properly_for_completed_spans() throws IOException {
+        // given: valid span that has been completed, and JSON string from Span.toJson()
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, spanPurpose).build();
+        completeSpan(validSpan);
+        assertThat(validSpan.isCompleted()).isTrue();
+        String json = validSpan.toJSON();
+
+        // when: fromJson is called
+        Span spanFromJson = SpanParser.fromJSON(json);
+
+        // then: the original span and the fromJson() span values should be exactly the same
+        verifySpanDeepEquals(validSpan, spanFromJson, true);
+    }
+
+    @Test
+    public void fromJson_should_return_null_for_garbage_input() throws IOException {
+        // given: garbage input
+        String garbageInput = "garbagio";
+
+        // when: fromJson is called
+        Span spanFromJson = SpanParser.fromJSON(garbageInput);
+
+        // then: the return value should be null
+        assertThat(spanFromJson).isNull();
+    }
+
+    @Test
+    public void fromJson_returns_null_if_sampleable_field_is_missing() throws IOException {
+        // given
+        Span validSpan = createFilledOutSpan(true);
+        String validJson = validSpan.toJSON();
+        String invalidJson = validJson.replace(String.format(",\"%s\":\"%s\"", SpanParser.SAMPLEABLE_FIELD, String.valueOf(validSpan.isSampleable())), "");
+
+        // when
+        Span result = SpanParser.fromJSON(invalidJson);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void fromJson_returns_null_if_startTimeEpochMicros_field_is_missing() throws IOException {
+        // given
+        Span validSpan = createFilledOutSpan(true);
+        String validJson = validSpan.toJSON();
+        String invalidJson = validJson.replace(
+            String.format(",\"%s\":\"%s\"", SpanParser.START_TIME_EPOCH_MICROS_FIELD, String.valueOf(validSpan.getSpanStartTimeEpochMicros())),
+            ""
+        );
+
+        // when
+        Span result = SpanParser.fromJSON(invalidJson);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @DataProvider(value = {
+        "",
+        "foobar-not-a-real-enum-value"
+    }, splitBy = "\\|")
+    @Test
+    public void fromJson_returns_span_with_UNKNOWN_span_purpose_if_spanPurpose_field_is_missing_or_garbage(String badValue) throws IOException {
+        // given
+        Span validSpan = createFilledOutSpan(true);
+        String validJson = validSpan.toJSON();
+        if (badValue.trim().length() > 0) {
+            badValue = ",\"spanPurpose\":\"" + badValue + "\"";
+        }
+        String invalidJson = validJson.replace(
+            String.format(",\"%s\":\"%s\"", SpanParser.SPAN_PURPOSE_FIELD, validSpan.getSpanPurpose().name()),
+            badValue
+        );
+        assertThat(validSpan.getSpanPurpose()).isNotEqualTo(SpanPurpose.UNKNOWN);
+
+        // when
+        Span result = SpanParser.fromJSON(invalidJson);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getSpanPurpose()).isEqualTo(SpanPurpose.UNKNOWN);
+    }
+
+    private Map<String, String> deserializeKeyValueSpanString(String keyValStr) {
+        Map<String, String> map = new HashMap<>();
+        String[] fields = keyValStr.split(",");
+        for (String field : fields) {
+            String[] info = field.split("=");
+            map.put(info[0], info[1]);
+        }
+        return map;
+    }
+
+    @DataProvider( value = {
+            "NULL",
+            "SINGLE_VALUE",
+            "MULTIPLE_VALUES",
+            "SPECIAL_CHARS"
+        })
+    @Test
+    public void toKeyValueString_should_function_properly_when_there_are_no_null_values(TAG_SET tags) throws IOException {
+        // given: valid known span without any null values, span completed (so that end time is not null) and key/value string from Span.toKeyValueString()
+        Span validSpan = createFilledOutSpan(true,tags.getTags());
+        assertThat(validSpan.getTraceId()).isNotEmpty();
+        assertThat(validSpan.getUserId()).isNotEmpty();
+        assertThat(validSpan.getParentSpanId()).isNotEmpty();
+        assertThat(validSpan.getSpanName()).isNotEmpty();
+        assertThat(validSpan.getSpanId()).isNotEmpty();
+        assertThat(validSpan.getDurationNanos()).isNotNull();
+        assertThat(validSpan.isCompleted()).isTrue();
+        assertThat(validSpan.getSpanPurpose()).isNotNull();
+        String keyValueStr = validSpan.toKeyValueString();
+
+        // when: the string is deserialized into a map
+        Map<String, String> deserializedValues = deserializeKeyValueSpanString(keyValueStr);
+
+        // then: the original span and deserialized map values should be exactly the same
+        verifySpanEqualsDeserializedValues(validSpan, deserializedValues);
+    }
+
+    @Test
+    public void toKeyValueString_should_function_properly_when_there_are_null_values() throws IOException {
+        // given: valid span with null values and key/value string from Span.toKeyValueString()
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, null).build();
+        assertThat(validSpan.getParentSpanId()).isNull();
+        assertThat(validSpan.getUserId()).isNull();
+        assertThat(validSpan.getDurationNanos()).isNull();
+        String keyValueStr = validSpan.toKeyValueString();
+
+        // when: the string is deserialized into a map
+        Map<String, String> deserializedValues = deserializeKeyValueSpanString(keyValueStr);
+
+        // then: the original span and deserialized map values should be exactly the same
+        verifySpanEqualsDeserializedValues(validSpan, deserializedValues);
+    }
+
+    @Test
+    public void toKeyValueString_should_function_properly_for_non_completed_spans() throws IOException {
+        // given: valid span and key/value string from Span.toKeyValueString()
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, spanPurpose).build();
+        String keyValueStr = validSpan.toKeyValueString();
+        assertThat(validSpan.isCompleted()).isFalse();
+
+        // when: the string is deserialized into a map
+        Map<String, String> deserializedValues = deserializeKeyValueSpanString(keyValueStr);
+
+        // then: the original span and deserialized map values should be exactly the same
+        verifySpanEqualsDeserializedValues(validSpan, deserializedValues);
+    }
+
+    @Test
+    public void toKeyValueString_should_function_properly_for_completed_spans() throws IOException {
+        // given: valid span and completed, and key/value string from Span.toKeyValueString()
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, spanPurpose).build();
+        completeSpan(validSpan);
+        assertThat(validSpan.isCompleted()).isTrue();
+        String keyValueStr = validSpan.toKeyValueString();
+
+        // when: the string is deserialized into a map
+        Map<String, String> deserializedValues = deserializeKeyValueSpanString(keyValueStr);
+
+        // then: the original span and deserialized map values should be exactly the same
+        verifySpanEqualsDeserializedValues(validSpan, deserializedValues);
+    }
+
+    @Test
+    public void toKeyValueString_should_use_cached_key_value_string() {
+        // given
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, spanPurpose).build();
+        String uuidString = UUID.randomUUID().toString();
+        Whitebox.setInternalState(validSpan, "cachedKeyValueRepresentation", uuidString);
+
+        // when
+        String toKeyValueStringResult = validSpan.toKeyValueString();
+
+        // then
+        assertThat(toKeyValueStringResult).isEqualTo(uuidString);
+    }
+
+    @Test
+    public void complete_should_reset_cached_key_value_string() throws IOException {
+        // given
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, spanPurpose).build();
+        String uuidString = UUID.randomUUID().toString();
+        Whitebox.setInternalState(validSpan, "cachedKeyValueRepresentation", uuidString);
+
+        // when
+        String beforeCompleteKeyValueString = validSpan.toKeyValueString();
+        completeSpan(validSpan);
+
+        // then
+        String afterCompleteKeyValueString = validSpan.toKeyValueString();
+        assertThat(afterCompleteKeyValueString).isNotEqualTo(beforeCompleteKeyValueString);
+        assertThat(afterCompleteKeyValueString).isNotEqualTo(uuidString);
+        Map<String, String> deserializedValues = deserializeKeyValueSpanString(afterCompleteKeyValueString);
+        verifySpanEqualsDeserializedValues(validSpan, deserializedValues);
+    }
+
+    @DataProvider( value = {
+            "NULL",
+            "SINGLE_VALUE",
+            "MULTIPLE_VALUES",
+            "SPECIAL_CHARS"
+        })
+    @Test
+    public void fromKeyValueString_should_function_properly_when_there_are_no_null_values(TAG_SET tags) {
+        // given: valid span without any null values, completed (so that end time is not null) and key/value string from Span.fromKeyValueString()
+        Span validSpan = createFilledOutSpan(true, tags.getTags());
+        assertThat(validSpan).isNotNull();
+        assertThat(validSpan.getTraceId()).isNotNull();
+        assertThat(validSpan.getUserId()).isNotNull();
+        assertThat(validSpan.getParentSpanId()).isNotNull();
+        assertThat(validSpan.getSpanName()).isNotNull();
+        assertThat(validSpan.getSpanId()).isNotNull();
+        assertThat(validSpan.getDurationNanos()).isNotNull();
+        assertThat(validSpan.isCompleted()).isTrue();
+        assertThat(validSpan.getSpanPurpose()).isNotNull();
+        assertThat(validSpan.getTags()).isNotNull();
+        String keyValStr = validSpan.toKeyValueString();
+
+        // when: toKeyValueString is called
+        Span spanFromKeyValStr = SpanParser.fromKeyValueString(keyValStr);
+
+        // then: the original span and the fromKeyValueString() span values should be exactly the same
+        verifySpanDeepEquals(validSpan, spanFromKeyValStr, true);
+    }
+
+    @Test
+    public void fromKeyValueString_should_function_properly_when_there_are_null_values() throws IOException {
+        // given: valid span with null values and key/value string from Span.fromKeyValueString()
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, null).build();
+        assertThat(validSpan.getParentSpanId()).isNull();
+        assertThat(validSpan.getUserId()).isNull();
+        assertThat(validSpan.getDurationNanos()).isNull();
+        String keyValStr = validSpan.toKeyValueString();
+
+        // when: toKeyValueString is called
+        Span spanFromKeyValStr = SpanParser.fromKeyValueString(keyValStr);
+
+        // then: the original span and the fromKeyValueString() span values should be exactly the same
+        verifySpanDeepEquals(validSpan, spanFromKeyValStr, true);
+    }
+
+    @Test
+    public void fromKeyValueString_should_function_properly_for_non_completed_spans() throws IOException {
+        // given: valid, non-completed span and key/value string from Span.fromKeyValueString()
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, spanPurpose).build();
+        String keyValStr = validSpan.toKeyValueString();
+        assertThat(validSpan.isCompleted()).isFalse();
+
+        // when: toKeyValueString is called
+        Span spanFromKeyValStr = SpanParser.fromKeyValueString(keyValStr);
+
+        // then: the original span and the fromKeyValueString() span values should be exactly the same
+        verifySpanDeepEquals(validSpan, spanFromKeyValStr, true);
+    }
+
+    @Test
+    public void fromKeyValueString_should_function_properly_for_completed_spans() throws IOException {
+        // given: valid span that has been completed, and key/value string from Span.fromKeyValueString()
+        Span validSpan = Span.generateRootSpanForNewTrace(spanName, spanPurpose).build();
+        completeSpan(validSpan);
+        assertThat(validSpan.isCompleted()).isTrue();
+        String keyValStr = validSpan.toKeyValueString();
+
+        // when: toKeyValueString is called
+        Span spanFromKeyValStr = SpanParser.fromKeyValueString(keyValStr);
+
+        // then: the original span and the fromKeyValueString() span values should be exactly the same
+        verifySpanDeepEquals(validSpan, spanFromKeyValStr, true);
+    }
+
+    @Test
+    public void fromKeyValueString_should_return_null_for_garbage_input() throws IOException {
+        // given: garbage input
+        String garbageInput = "garbagio";
+
+        // when: fromKeyValueString is called
+        Span spanFromKeyValStr = SpanParser.fromKeyValueString(garbageInput);
+
+        // then: the return value should be null
+        assertThat(spanFromKeyValStr).isNull();
+    }
+
+    @Test
+    public void fromKeyValueString_returns_null_if_sampleable_field_is_missing() throws IOException {
+        // given
+        Span validSpan = createFilledOutSpan(true);
+        String validKeyValStr = validSpan.toKeyValueString();
+        String invalidKeyValStr = validKeyValStr.replace(String.format(",%s=%s", SpanParser.SAMPLEABLE_FIELD, String.valueOf(validSpan.isSampleable())), "");
+
+        // when
+        Span result = SpanParser.fromKeyValueString(invalidKeyValStr);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void fromKeyValueString_returns_null_if_startTimeEpochMicros_field_is_missing() throws IOException {
+        // given
+        Span validSpan = createFilledOutSpan(true);
+        String validKeyValStr = validSpan.toKeyValueString();
+        String invalidKeyValStr = validKeyValStr.replace(
+            String.format(",%s=%s", SpanParser.START_TIME_EPOCH_MICROS_FIELD, String.valueOf(validSpan.getSpanStartTimeEpochMicros())),
+            ""
+        );
+
+        // when
+        Span result = SpanParser.fromKeyValueString(invalidKeyValStr);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @DataProvider(value = {
+        "",
+        "foobar-not-a-real-enum-value"
+    }, splitBy = "\\|")
+    @Test
+    public void fromKeyValueString_returns_span_with_UNKNOWN_span_purpose_if_spanPurpose_field_is_missing_or_garbage(String badValue) throws IOException {
+        // given
+        Span validSpan = createFilledOutSpan(true);
+        String validKeyValStr = validSpan.toKeyValueString();
+        if (badValue.trim().length() > 0) {
+            badValue = ",spanPurpose=" + badValue;
+        }
+        String invalidKeyValStr = validKeyValStr.replace(
+            String.format(",%s=%s", SpanParser.SPAN_PURPOSE_FIELD, String.valueOf(validSpan.getSpanPurpose())),
+            badValue
+        );
+        assertThat(validSpan.getSpanPurpose()).isNotEqualTo(SpanPurpose.UNKNOWN);
+
+        // when
+        Span result = SpanParser.fromKeyValueString(invalidKeyValStr);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getSpanPurpose()).isEqualTo(SpanPurpose.UNKNOWN);
+    }
+    
+    
+}

--- a/wingtips-zipkin2/src/main/java/com/nike/wingtips/zipkin2/util/WingtipsToZipkinSpanConverterDefaultImpl.java
+++ b/wingtips-zipkin2/src/main/java/com/nike/wingtips/zipkin2/util/WingtipsToZipkinSpanConverterDefaultImpl.java
@@ -6,6 +6,7 @@ import com.nike.wingtips.Span.SpanPurpose;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import zipkin2.Endpoint;
@@ -24,7 +25,7 @@ public class WingtipsToZipkinSpanConverterDefaultImpl implements WingtipsToZipki
     public zipkin2.Span convertWingtipsSpanToZipkinSpan(Span wingtipsSpan, Endpoint zipkinEndpoint) {
         long durationMicros = TimeUnit.NANOSECONDS.toMicros(wingtipsSpan.getDurationNanos());
 
-        return zipkin2.Span
+        zipkin2.Span.Builder builder = zipkin2.Span
             .newBuilder()
             .id(wingtipsSpan.getSpanId())
             .name(wingtipsSpan.getSpanName())
@@ -33,8 +34,14 @@ public class WingtipsToZipkinSpanConverterDefaultImpl implements WingtipsToZipki
             .timestamp(wingtipsSpan.getSpanStartTimeEpochMicros())
             .duration(durationMicros)
             .localEndpoint(zipkinEndpoint)
-            .kind(determineZipkinKind(wingtipsSpan))
-            .build();
+            .kind(determineZipkinKind(wingtipsSpan));
+        
+        // Iterate over existing tags and add them one-by-one, no current interface to set a collection of tags
+        for (Map.Entry<String, String> tagEntry : wingtipsSpan.getTags().entrySet()) {
+        		builder.putTag(tagEntry.getKey(), tagEntry.getValue());
+        }
+            
+        return builder.build();
     }
 
     @SuppressWarnings("WeakerAccess")


### PR DESCRIPTION
Added support for tags on the Span object and the supporting Zipkin libraries.  I also split the serialization methods into their own class for easier testing and separation of concerns:  'com.nike.wingtips.util.SpanParser`