### PR TITLE
Adding tags for uri, response code, error and method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .gradle
 build/
 gradle-app.setting
+bin/
 
 ### IntelliJ stuff
 .idea/
@@ -11,3 +12,11 @@ gradle-app.setting
 out/
 classes/
 .idea_modules/
+
+### Eclipse
+.classpath
+.project
+.settings
+
+# Mac stuff
+.DS_Store

--- a/samples/sample-spring-boot/src/main/resources/application.properties
+++ b/samples/sample-spring-boot/src/main/resources/application.properties
@@ -13,6 +13,10 @@ wingtips.user-id-header-keys=userid,altuserid
 #   Must be either JSON or KEY_VALUE. If missing then the span logging format will not be changed (defaults to JSON).
 wingtips.span-logging-format=KEY_VALUE
 
+# Determines the set of tags that will be used to record metadata from the request and response.  These standard tags
+# are often used by visualization tools. Must be one of ZIPKIN, OPENTRACING, or NONE.
+wingtips.server-side-span-tagging-strategy=ZIPKIN
+
 # =========== WINGTIPS-ZIPKIN CONFIG PROPERTIES (See WingtipsZipkinProperties) ============
 
 # Disables the Wingtips Zipkin integration if and only if this property value is set to true.

--- a/wingtips-apache-http-client/src/main/java/com/nike/wingtips/apache/httpclient/WingtipsHttpClientBuilder.java
+++ b/wingtips-apache-http-client/src/main/java/com/nike/wingtips/apache/httpclient/WingtipsHttpClientBuilder.java
@@ -1,13 +1,13 @@
 package com.nike.wingtips.apache.httpclient;
 
-import com.nike.wingtips.Span;
-import com.nike.wingtips.Span.SpanPurpose;
-import com.nike.wingtips.Tracer;
-import com.nike.wingtips.apache.httpclient.util.WingtipsApacheHttpClientUtil;
+import static com.nike.wingtips.apache.httpclient.util.WingtipsApacheHttpClientUtil.propagateTracingHeaders;
+
+import java.io.IOException;
 
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -18,10 +18,16 @@ import org.apache.http.conn.routing.HttpRoute;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.execchain.ClientExecChain;
 import org.apache.http.protocol.HttpProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-
-import static com.nike.wingtips.apache.httpclient.util.WingtipsApacheHttpClientUtil.propagateTracingHeaders;
+import com.nike.wingtips.Span;
+import com.nike.wingtips.Span.SpanPurpose;
+import com.nike.wingtips.Tracer;
+import com.nike.wingtips.apache.httpclient.tag.ApacheHttpClientTagAdapter;
+import com.nike.wingtips.apache.httpclient.util.WingtipsApacheHttpClientUtil;
+import com.nike.wingtips.tags.HttpTagStrategy;
+import com.nike.wingtips.tags.OpenTracingTagStrategy;
 
 /**
  * (NOTE: This class is recommended instead of {@link WingtipsApacheHttpClientInterceptor} if you have control over
@@ -71,8 +77,12 @@ import static com.nike.wingtips.apache.httpclient.util.WingtipsApacheHttpClientU
 @SuppressWarnings("WeakerAccess")
 public class WingtipsHttpClientBuilder extends HttpClientBuilder {
 
+    private static final Logger logger = LoggerFactory.getLogger(WingtipsHttpClientBuilder.class);
+    
     protected boolean surroundCallsWithSubspan;
 
+    protected HttpTagStrategy<HttpRequest, HttpResponse> tagStrategy;
+    
     /**
      * Creates a new instance with the subspan option turned on.
      */
@@ -83,13 +93,27 @@ public class WingtipsHttpClientBuilder extends HttpClientBuilder {
     /**
      * Creates a new instance with the subspan option set to the value of the {@code surroundCallsWithSubspan} argument.
      * 
+     * Uses a default tag strategy of {@codeApacheHttpClientTagStrategy}
+     * 
      * @param surroundCallsWithSubspan Pass in true to have requests surrounded in a subspan, false to disable the
      * subspan option.
      */
     public WingtipsHttpClientBuilder(boolean surroundCallsWithSubspan) {
-        this.surroundCallsWithSubspan = surroundCallsWithSubspan;
+        this(surroundCallsWithSubspan, new OpenTracingTagStrategy<HttpRequest, HttpResponse>(new ApacheHttpClientTagAdapter()));
     }
 
+    /**
+     * Creates a new instance with the subspan option set to the value of the {@code surroundCallsWithSubspan} argument.
+     * 
+     * @param surroundCallsWithSubspan Pass in true to have requests surrounded in a subspan, false to disable the
+     * subspan option.
+     * @param tagStrategy The span tag strategy to use
+     */
+    public WingtipsHttpClientBuilder(boolean surroundCallsWithSubspan, HttpTagStrategy<HttpRequest, HttpResponse> tagStrategy) {
+            this.surroundCallsWithSubspan = surroundCallsWithSubspan;
+            this.tagStrategy = tagStrategy;
+    }
+    
     /**
      * @return Static factory method for creating a new {@link WingtipsHttpClientBuilder} instance with the subspan
      * option turned on.
@@ -102,10 +126,22 @@ public class WingtipsHttpClientBuilder extends HttpClientBuilder {
      * @param surroundCallsWithSubspan Pass in true to have requests surrounded in a subspan, false to disable the
      * subspan option.
      * @return Static factory method for creating a new {@link WingtipsHttpClientBuilder} instance with the subspan
-     * option set to the value of the {@code surroundCallsWithSubspan} argument.
+     * option set to the value of the {@code surroundCallsWithSubspan} argument and a tag strategy of
+     * {@codeApacheHttpClientTagStrategy}
      */
     public static WingtipsHttpClientBuilder create(boolean surroundCallsWithSubspan) {
         return new WingtipsHttpClientBuilder(surroundCallsWithSubspan);
+    }
+    
+    /**
+     * @param surroundCallsWithSubspan Pass in true to have requests surrounded in a subspan, false to disable the
+     * subspan option.
+     * @param tagStrategy The span tag strategy to use
+     * @return Static factory method for creating a new {@link WingtipsHttpClientBuilder} instance with the subspan
+     * option set to the value of the {@code surroundCallsWithSubspan} argument.
+     */
+    public static WingtipsHttpClientBuilder create(boolean surroundCallsWithSubspan, HttpTagStrategy<HttpRequest, HttpResponse> tagStrategy) {
+        return new WingtipsHttpClientBuilder(surroundCallsWithSubspan, tagStrategy);
     }
 
     @Override
@@ -119,24 +155,82 @@ public class WingtipsHttpClientBuilder extends HttpClientBuilder {
                                                  HttpClientContext clientContext,
                                                  HttpExecutionAware execAware) throws IOException, HttpException {
 
-                Tracer tracer = Tracer.getInstance();
-                Span spanAroundCall = null;
-                if (myHttpClientSurroundCallsWithSubspan) {
-                    // Will start a new trace if necessary, or a subspan if a trace is already in progress.
-                    spanAroundCall = tracer.startSpanInCurrentContext(getSubspanSpanName(request), SpanPurpose.CLIENT);
+                if(myHttpClientSurroundCallsWithSubspan) {
+                    return createNewSubSpanAndExecute(route, request, clientContext, execAware);
                 }
+                return propagateHeadersAndExecute(route, request, clientContext, execAware);
+            }
+            
+            protected CloseableHttpResponse createNewSubSpanAndExecute(HttpRoute route, HttpRequestWrapper request,
+                                                 HttpClientContext clientContext,
+                                                 HttpExecutionAware execAware) throws IOException, HttpException {
+                
+                // Will start a new trace if necessary, or a subspan if a trace is already in progress.
+                Span spanAroundCall = Tracer.getInstance().startSpanInCurrentContext(getSubspanSpanName(request), SpanPurpose.CLIENT);
+                tagSpanWithRequestAttributes(spanAroundCall, request);
 
                 try {
-                    propagateTracingHeaders(request, tracer.getCurrentSpan());
-                    return protocolExec.execute(route, request, clientContext, execAware);
+                    CloseableHttpResponse response = propagateHeadersAndExecute(route, request, clientContext, execAware);
+                    tagSpanWithResponseAttributes(spanAroundCall, response);
+                    return response;
+                } catch(Throwable t) {
+                        handleErroredRequestTags(spanAroundCall, t);
+                        throw t;
                 }
                 finally {
-                    if (spanAroundCall != null) {
-                        // Span.close() contains the logic we want - if the spanAroundCall was an overall span (new
-                        //      trace) then tracer.completeRequestSpan() will be called, otherwise it's a subspan and
-                        //      tracer.completeSubSpan() will be called.
-                        spanAroundCall.close();
-                    }
+                    // Span.close() contains the logic we want - if the spanAroundCall was an overall span (new
+                    //      trace) then tracer.completeRequestSpan() will be called, otherwise it's a subspan and
+                    //      tracer.completeSubSpan() will be called.
+                    spanAroundCall.close();
+                }
+            }
+            
+            protected CloseableHttpResponse propagateHeadersAndExecute(HttpRoute route, HttpRequestWrapper request,
+                    HttpClientContext clientContext,
+                    HttpExecutionAware execAware) throws IOException, HttpException {
+                propagateTracingHeaders(request, Tracer.getInstance().getCurrentSpan());
+                return protocolExec.execute(route, request, clientContext, execAware);
+            }
+            
+            /**
+             * Broken out as a separate method so we can surround it in a try{} to ensure we don't break the overall
+             * span handling with exceptions from the {@code tagStrategy}.
+             * @param span The span to be tagged
+             * @param requestObj The request context to use for tag values
+             */
+            private void tagSpanWithRequestAttributes(Span span, HttpRequest requestObj) {
+                try {
+                    tagStrategy.tagSpanWithRequestAttributes(span, requestObj);
+                } catch(Throwable taggingException) {
+                    logger.warn("Unable to tag span with request attributes", taggingException);
+                }
+            }
+
+            /**
+             * Broken out as a separate method so we can surround it in a try{} to ensure we don't break the overall
+             * span handling with exceptions from the {@code tagStrategy}.
+             * @param span The span to be tagged
+             * @param responseObj The response context to be used for tag values
+             */
+            private void tagSpanWithResponseAttributes(Span span, HttpResponse responseObj) {
+                try {
+                    tagStrategy.tagSpanWithResponseAttributes(span, responseObj);
+                } catch(Throwable taggingException) {
+                    logger.warn("Unable to tag span with response attributes", taggingException);
+                }
+            }
+
+            /**
+             * Broken out as a separate method so we can surround it in a try{} to ensure we don't break the overall
+             * span handling with exceptions from the {@code tagStrategy}.
+             * @param span The span to be tagged
+             * @param throwable The exception context to use for tag values
+             */
+            private  void handleErroredRequestTags(Span span, Throwable throwable) {
+                try {
+                    tagStrategy.handleErroredRequest(span, throwable);
+                } catch(Throwable taggingException) {
+                    logger.warn("Unable to tag errored span with exception", taggingException);
                 }
             }
         };

--- a/wingtips-apache-http-client/src/main/java/com/nike/wingtips/apache/httpclient/tag/ApacheHttpClientTagAdapter.java
+++ b/wingtips-apache-http-client/src/main/java/com/nike/wingtips/apache/httpclient/tag/ApacheHttpClientTagAdapter.java
@@ -1,0 +1,42 @@
+package com.nike.wingtips.apache.httpclient.tag;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+
+import com.nike.wingtips.tags.HttpTagAdapter;
+
+public class ApacheHttpClientTagAdapter implements HttpTagAdapter<HttpRequest, HttpResponse> {
+
+    @Override
+    public boolean isErrorResponse(HttpResponse response) {
+        return getResponseStatusCode(response) >= 500;
+    }
+
+    /**
+     * TODO This returns the full URL vs the URI e.g {@code "/endpoint"}
+     */
+    @Override
+    public String getRequestUri(HttpRequest request) {
+        return request.getRequestLine().getUri();
+    }
+
+    @Override
+    public String getResponseHttpStatus(HttpResponse response) {
+        return String.valueOf(getResponseStatusCode(response));
+    }
+
+    @Override
+    public String getRequestHttpMethod(HttpRequest request) {
+        return request.getRequestLine().getMethod();
+    }
+
+    private int getResponseStatusCode(HttpResponse response) {
+        return response.getStatusLine().getStatusCode();
+    }
+
+    @Override
+    public String getRequestUrl(HttpRequest request) {
+        return request.getRequestLine().getUri();
+    }
+
+}

--- a/wingtips-core/src/main/java/com/nike/wingtips/tags/HttpTagAdapter.java
+++ b/wingtips-core/src/main/java/com/nike/wingtips/tags/HttpTagAdapter.java
@@ -1,0 +1,46 @@
+package com.nike.wingtips.tags;
+
+/**
+ * Implementations know how to extract basic HTTP properties from HTTP Request
+ * and Response objects.  {@code HttpTagAdapters} are used by a {@code HttpTagStrategy}
+ * to extract the necessary tag values.
+ * 
+ * @author Brandon Currie
+ * 
+ */
+public interface HttpTagAdapter <REQ,RES> {
+
+    /**
+     * @return true if the current {@code Span} should be tagged as having an errd state based on the response object. 
+     */
+    public boolean isErrorResponse(RES response);
+
+    /**
+     * @return The full URL of the request
+     * 
+     * @param request - The request object to be inspected
+     */
+    public String getRequestUrl(REQ request);
+    
+    /**
+     * @return The URI of the request
+     * 
+     * @param request - The request object to be inspected
+     */
+    public String getRequestUri(REQ request);
+    
+    /**
+     * Returns the http status code from the provided response object
+     * @param response To be inspected to determine the http status code
+     * @return The {@code String} representation of the http status code
+     */
+    public String getResponseHttpStatus(RES response);
+
+    /**
+     * The HTTP Method used. e.g "GET" or "POST" ..
+     * @param request The request object to be inspected
+     * @return The HTTP Method
+     */
+    public String getRequestHttpMethod(REQ request);
+
+}

--- a/wingtips-core/src/main/java/com/nike/wingtips/tags/HttpTagStrategy.java
+++ b/wingtips-core/src/main/java/com/nike/wingtips/tags/HttpTagStrategy.java
@@ -1,0 +1,40 @@
+package com.nike.wingtips.tags;
+
+import com.nike.wingtips.Span;
+
+/**
+ * There are many libraries that facilitate HTTP Requests.  This interface allows for a
+ * consistent approach to tag a span with request and response details without having knowledge
+ * of the underlying libraries facilitating the request/response. 
+ * 
+ * The intent is to allow for easy implementation by surrounding an HTTP call using
+ * a pattern as follows within an intercepter or filter:
+ * <pre>
+ * execute(RequestObj request) {
+       try {
+           ...
+           tagStrategy.tagSpanWithRequestAttributes(span, request);
+           Response response = execution.execute(request);
+           tagStrategy.tagSpanWithResponseAttributes(span, response);
+           return response;
+           ...
+       } catch(Throwable t) {
+           tagStrategy.handleErroredRequest(span, t);
+           throw t;
+       } finally {...}
+   }
+ * </pre>
+ * 
+ * @author Brandon Currie
+ *
+ * @param <REQ> The object representing the http request
+ * @param <RES> The object representing the http response
+ */
+public interface HttpTagStrategy <REQ, RES> {
+
+    public abstract void tagSpanWithRequestAttributes(Span span, REQ requestObj);
+
+    public abstract void tagSpanWithResponseAttributes(Span span, RES responseObj);
+
+    public abstract void handleErroredRequest(Span span, Throwable throwable);
+}

--- a/wingtips-core/src/main/java/com/nike/wingtips/tags/NoOpTagStrategy.java
+++ b/wingtips-core/src/main/java/com/nike/wingtips/tags/NoOpTagStrategy.java
@@ -1,0 +1,22 @@
+package com.nike.wingtips.tags;
+
+import com.nike.wingtips.Span;
+
+public class NoOpTagStrategy <REQ, RES> implements HttpTagStrategy<REQ, RES> {
+
+    @Override
+    public void tagSpanWithRequestAttributes(Span span, REQ requestObj) {
+        // intentionally do nothing
+    }
+
+    @Override
+    public void tagSpanWithResponseAttributes(Span span, RES responseObj) {
+        // intentionally do nothing
+    }
+
+    @Override
+    public void handleErroredRequest(Span span, Throwable throwable) {
+        // intentionally do nothing
+    }
+
+}

--- a/wingtips-core/src/main/java/com/nike/wingtips/tags/OpenTracingTagStrategy.java
+++ b/wingtips-core/src/main/java/com/nike/wingtips/tags/OpenTracingTagStrategy.java
@@ -1,0 +1,49 @@
+package com.nike.wingtips.tags;
+
+import com.nike.wingtips.Span;
+
+/**
+ * In an effort to match tag patterns consistent with other implementations and with the OpenTracing standards, this class
+ * is responsible for adding the following tags to the {@code Span}:
+ * <ul>
+ *     <li>http.url</li>
+ *     <li>http.status_code</li>
+ *     <li>http.method</li>
+ *     <li>error</li>
+ * </ul>
+ * 
+ * These tag names are based on names provided via OpenTracing's <a href="https://github.com/opentracing/opentracing-java/blob/master/opentracing-api/src/main/java/io/opentracing/tag/Tags.java">Tags.java</a>
+ */
+public class OpenTracingTagStrategy <REQ,RES> implements HttpTagStrategy<REQ,RES> {
+
+    protected HttpTagAdapter<REQ,RES> adapter;
+
+    public OpenTracingTagStrategy(HttpTagAdapter<REQ,RES> adapter) {
+        this.adapter = adapter;
+    }
+
+    @Override
+    public void tagSpanWithRequestAttributes(Span span, REQ requestObj) {
+        span.putTag(KnownOpenTracingTags.HTTP_METHOD, adapter.getRequestHttpMethod(requestObj));
+        span.putTag(KnownOpenTracingTags.HTTP_URL, adapter.getRequestUrl(requestObj));
+    }
+
+    @Override
+    public void tagSpanWithResponseAttributes(Span span, RES responseObj) {
+        span.putTag(KnownOpenTracingTags.HTTP_STATUS, adapter.getResponseHttpStatus(responseObj));
+        if (adapter.isErrorResponse(responseObj)) {
+            addErrorTagToSpan(span);
+        }
+    }
+
+    @Override
+    public void handleErroredRequest(Span span, Throwable throwable) {
+        addErrorTagToSpan(span);
+    }
+
+    protected void addErrorTagToSpan(Span span) {
+        span.putTag(KnownOpenTracingTags.ERROR, "true");
+    }
+
+
+}

--- a/wingtips-core/src/main/java/com/nike/wingtips/tags/ZipkinTagStrategy.java
+++ b/wingtips-core/src/main/java/com/nike/wingtips/tags/ZipkinTagStrategy.java
@@ -1,0 +1,62 @@
+package com.nike.wingtips.tags;
+
+import com.nike.wingtips.Span;
+
+/**
+ * Applies {@code Zipkin} standard tags for:
+ * <ul>
+ * <li>http.method</li>
+ * <li>http.path</li>
+ * <li>http.url</li>
+ * <li>http.status_code</li>
+ * <li>error</li>
+ * </ul> 
+ * 
+ * The following known Zipkin tags are <strong>unimplemented</strong> in this strategy:
+ * <ul>
+ * <li>http.request.size</li>
+ * <li>http.response.size</li>
+ * <li>http.route</li>
+ * <li>http.host</li>
+ * </ul>
+ * 
+ * @author brandon
+ *
+ * @param <REQ> The expected request object type to be inspected
+ * @param <RES> The expected response object type to be inspected
+ * 
+ * @see <a href='https://github.com/openzipkin/brave/tree/master/instrumentation/http#span-data-policy'>Zipkin's Span Data Policy</a>
+ */
+public class ZipkinTagStrategy <REQ,RES> implements HttpTagStrategy<REQ,RES> {
+
+    protected HttpTagAdapter<REQ,RES> adapter;
+
+    public ZipkinTagStrategy(HttpTagAdapter<REQ,RES> adapter) {
+        this.adapter = adapter;
+    }
+
+    @Override
+    public void tagSpanWithRequestAttributes(Span span, REQ requestObj) {
+        span.putTag(KnownZipkinTags.HTTP_METHOD, adapter.getRequestHttpMethod(requestObj));
+        span.putTag(KnownZipkinTags.HTTP_PATH, adapter.getRequestUri(requestObj));
+        span.putTag(KnownZipkinTags.HTTP_URL, adapter.getRequestUrl(requestObj));
+    }
+
+    @Override
+    public void tagSpanWithResponseAttributes(Span span, RES responseObj) {
+        span.putTag(KnownZipkinTags.HTTP_STATUS_CODE, adapter.getResponseHttpStatus(responseObj));
+        if (adapter.isErrorResponse(responseObj)) {
+            addErrorTagToSpan(span);
+        }
+    }
+
+    @Override
+    public void handleErroredRequest(Span span, Throwable throwable) {
+        addErrorTagToSpan(span);
+    }
+
+    protected void addErrorTagToSpan(Span span) {
+        span.putTag(KnownZipkinTags.ERROR, "true");
+    }
+
+}

--- a/wingtips-core/src/test/java/com/nike/wingtips/tags/OpenTracingTagStrategyTest.java
+++ b/wingtips-core/src/test/java/com/nike/wingtips/tags/OpenTracingTagStrategyTest.java
@@ -1,0 +1,106 @@
+package com.nike.wingtips.tags;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.eq;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.nike.wingtips.Span;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+
+@RunWith(DataProviderRunner.class)
+public class OpenTracingTagStrategyTest {
+
+    private Map<String,String> spanTags = new HashMap<String,String>();
+
+    private Span spanMock;
+    private Object nullObj = null; // No need for this to have a value
+
+    private boolean isErroredResponse;
+    final String responseStatus = "200";
+    final String httpUrl = "/endpoint";
+    final String httpMethod = "GET";
+
+    @Before
+    public void setup() {
+        spanMock = mock(Span.class);
+
+        spanTags.clear();
+        doReturn(spanTags).when(spanMock).getTags();
+    }
+
+    @DataProvider(value = {
+            "true",
+            "false"
+    }, splitBy = "\\|")
+    @Test
+    public void tagspanwithresponseattributes_behaves_as_expected(boolean isErroredResponse) {
+        // given
+        this.isErroredResponse = isErroredResponse;
+
+        // when
+        openTracingTagStrategy.tagSpanWithResponseAttributes(spanMock, nullObj);
+
+        // then
+        verify(spanMock).putTag(eq(KnownOpenTracingTags.HTTP_STATUS), eq(responseStatus));
+
+        if(isErroredResponse) {
+            // the error tag should only have a value if isErroredResponse is true
+            verify(spanMock).putTag(eq(KnownOpenTracingTags.ERROR), eq("true"));
+        } else {
+            // there shouldn't be any value for the error tag
+            verify(spanMock, never()).putTag(eq(KnownOpenTracingTags.ERROR), any(String.class));
+        }
+    }
+
+    @Test
+    public void tagspanwithrequestattributes_behaves_as_expected() {
+        // when
+        openTracingTagStrategy.tagSpanWithRequestAttributes(spanMock, nullObj);
+
+        // then
+        verify(spanMock).putTag(eq(KnownOpenTracingTags.HTTP_METHOD), eq(httpMethod));
+        verify(spanMock).putTag(eq(KnownOpenTracingTags.HTTP_URL), eq(httpUrl));
+    }
+
+    private HttpTagAdapter<Object,Object> tagAdapter = new HttpTagAdapter<Object,Object>() {
+
+        @Override
+        public boolean isErrorResponse(Object response) {
+            return isErroredResponse;
+        }
+
+        @Override
+        public String getResponseHttpStatus(Object response) {
+            return responseStatus;
+        }
+
+        @Override
+        public String getRequestHttpMethod(Object request) {
+            return httpMethod;
+        }
+
+        @Override
+        public String getRequestUrl(Object request) {
+            return httpUrl;
+        }
+
+        @Override
+        public String getRequestUri(Object request) {
+            return null;
+        }
+
+    };
+
+    private OpenTracingTagStrategy<Object,Object> openTracingTagStrategy = new OpenTracingTagStrategy<Object,Object>(tagAdapter);
+}

--- a/wingtips-servlet-api/README.md
+++ b/wingtips-servlet-api/README.md
@@ -12,7 +12,8 @@ in and completing it when the request finishes. This filter automatically uses `
 information from the incoming request headers for the new span if available. Sets the `X-B3-TraceId` response header to 
 the Trace ID for each request. Supports Servlet 3 environments (including asynchronous requests) as well as Servlet 2.x 
 environments. You can set the `user-id-header-keys-list` servlet filter param if you expect your service to receive any 
-request headers that represent a user ID (if you don't have any user ID headers then this can be ignored).
+request headers that represent a user ID (if you don't have any user ID headers then this can be ignored). By default, 
+this filter will tag spans with metadata from the request and response using the [OpenTracingTagStrategy](../wingtips-core/src/main/java/com/nike/wingtips/tags/OpenTracingTagStrategy.java). 
 
 Please make sure you have read the [base project README.md](../README.md). This readme assumes you understand the 
 principles and usage instructions described there.
@@ -32,6 +33,10 @@ header keys that represent the user ID of the user making the call: `userid` or 
         <param-name>user-id-header-keys-list</param-name>
         <param-value>userid,altuserid</param-value>
     </init-param>
+    <init-param>
+        <param-name>server-side-span-tag-strategy</param-name>
+        <param-value>OPENTRACING</param-value>
+    </init-param>
 </filter>
 
 <filter-mapping>
@@ -42,6 +47,8 @@ header keys that represent the user ID of the user making the call: `userid` or 
 
 If your service does not have any user ID headers you can remove the `<init-param>` element entirely or set the 
 `<param-value>` to be empty.
+
+The filter will use `OPENTRACING` tag strategy by default if you remove the `<init-param>` for `server-side-span-tag-strategy`.  
 
 That's it for incoming requests. This Filter will do the right thing and start a root span or child span for incoming 
 requests (depending on whether or not the caller included tracing headers), add the trace ID to the response as a 
@@ -86,6 +93,55 @@ unintentional information leakage.
 See the [base project readme's section on propagation](../README.md#propagating_traces) for further details on 
 propagating tracing information. You may also want to consider
 [wrapping downstream calls in a subspan](../README.md#sub_spans_for_downstream_calls).
+
+### Server Request Span Tagging
+
+`HttpServletRequests` and `HttpServletResponses` handled by the `RequestTracingFilter` are passed to a `HttpTagStrategy`
+to add metadata to a Span in the form of tags. The [OpenTracingTagStrategy](../wingtips-core/src/main/java/com/nike/wingtips/tags/OpenTracingTagStrategy.java)
+is default.
+
+#### Using a pre-defined tag strategy
+
+The `HttpTagStrategy` is defined by the init param `server-side-span-tag-strategy`.  Valid values are:
+- `OPENTRACING` **default** - Uses the [OpenTracingTagStrategy](../wingtips-core/src/main/java/com/nike/wingtips/tags/OpenTracingTagStrategy.java)
+- `WINGTIPS` Uses the [WingtipsTagStrategy](../wingtips-core/src/main/java/com/nike/wingtips/tags/WingtipsTagStrategy.java)
+- `NONE` Uses the [NoOpTagStrategy](../wingtips-core/src/main/java/com/nike/wingtips/tags/NoOpTagStrategy.java)
+
+#### Providing your own tag strategy
+
+##### 1. Extend the `RequestTracingFilter` class
+
+To provide a custom tag strategy, extend the `RequestTracingFilter` and override
+`protected void initializeTagStrategy(FilterConfig filterConfig)` to return your
+tag strategy.  
+
+In this example, the provided strategy extends the OpenTracing implementation to 
+add a tag for the exception name:
+
+```java
+public class ErrorTaggingRequestTracingFilter extends RequestTracingFilter {
+    @Override
+    protected HttpTagStrategy<HttpServletRequest, HttpServletResponse> initializeTagStrategy(FilterConfig filterConfig)  {
+    		return new OpenTracingTagStrategy<HttpServletRequest, HttpServletResponse> (new ServletRequestTagAdapter()) {
+
+				@Override public void handleErroredRequest(Span span, Throwable throwable) {
+					super.handleErroredRequest(span, throwable);
+					span.putTag("error.class", throwable.getClass().getName());
+				}
+    		};
+    }    
+}
+```
+
+##### 2. Use your class in the servlet configuration
+
+``` xml
+<filter>
+    <filter-name>traceFilter</filter-name>
+    <filter-class>com.example.org.filter.ErrorTaggingRequestTracingFilter</filter-class>
+    <init-param>
+    ...
+```
 
 <a name="servlet_api_required_at_runtime"></a>
 ## NOTE - Servlet API dependency required at runtime

--- a/wingtips-servlet-api/build.gradle
+++ b/wingtips-servlet-api/build.gradle
@@ -22,4 +22,11 @@ dependencies {
             "io.rest-assured:rest-assured:$restAssuredVersion",
             "org.eclipse.jetty:jetty-webapp:$jettyVersion"
     )
+jacocoTestReport {
+    reports {
+        xml.enabled false
+        csv.enabled false
+        html.destination file("${buildDir}/jacocoHtml")
+    }
+}
 }

--- a/wingtips-servlet-api/src/main/java/com/nike/wingtips/servlet/tag/ServletRequestTagAdapter.java
+++ b/wingtips-servlet-api/src/main/java/com/nike/wingtips/servlet/tag/ServletRequestTagAdapter.java
@@ -1,0 +1,45 @@
+package com.nike.wingtips.servlet.tag;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.nike.wingtips.tags.HttpTagAdapter;
+
+public class ServletRequestTagAdapter implements HttpTagAdapter<HttpServletRequest, HttpServletResponse> {
+
+    /**
+     * Tag any span as errd if the response code is >= 500.  Assumes 4xx, and 3xx type errors are graceful, expected
+     * use cases. 
+     */
+    @Override
+    public boolean isErrorResponse(HttpServletResponse response) {
+        return response.getStatus() >= 500;
+    }
+
+    /** 
+     * The default is to use {@code request.getRequestURI()}. 
+     * Another plausible alternative the full URL without parameters: {@code request.getRequestURL()}
+     * 
+     * @param request - The {@code HttpServletRequest}
+     */
+    @Override
+    public String getRequestUrl(HttpServletRequest request) {
+        return request.getRequestURL().toString();
+    }
+
+    @Override
+    public String getResponseHttpStatus(HttpServletResponse responseObj) {
+        return String.valueOf(responseObj.getStatus());
+    }
+
+    @Override
+    public String getRequestHttpMethod(HttpServletRequest request) {
+        return request.getMethod();
+    }
+
+    @Override
+    public String getRequestUri(HttpServletRequest request) {
+        return request.getRequestURI();
+    }
+
+}

--- a/wingtips-servlet-api/src/test/java/com/nike/wingtips/servlet/ServletRequestTagAdapterTest.java
+++ b/wingtips-servlet-api/src/test/java/com/nike/wingtips/servlet/ServletRequestTagAdapterTest.java
@@ -1,0 +1,65 @@
+package com.nike.wingtips.servlet;
+
+import static org.mockito.Mockito.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import com.nike.wingtips.servlet.tag.ServletRequestTagAdapter;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+
+@RunWith(DataProviderRunner.class)
+public class ServletRequestTagAdapterTest {
+
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private ServletRequestTagAdapter adapter;
+    @Before
+    public void setup() {
+        adapter = new ServletRequestTagAdapter();
+        request = Mockito.mock(HttpServletRequest.class);
+        response = Mockito.mock(HttpServletResponse.class);
+    }
+    
+    @Test
+    public void fivehundred_responses_are_errors() {
+        doReturn(500).when(response).getStatus();
+        assert(adapter.isErrorResponse(response));
+        
+        doReturn(499).when(response).getStatus();
+        assert(!adapter.isErrorResponse(response));
+    }
+    
+    @Test
+    public void getRequestUri() {
+        String uri ="/endpoint";
+        doReturn(uri).when(request).getRequestURI();
+        assert(uri.equals(adapter.getRequestUri(request)));
+    }
+    
+    @Test
+    public void getRequestUrl() {
+        StringBuffer url = new StringBuffer("http://www.google.com");
+        doReturn(url).when(request).getRequestURL();
+        assert(url.toString().equals(adapter.getRequestUrl(request)));
+    }
+
+    @Test
+    public void getResponseHttpStatus() {
+        int status = 200;
+        doReturn(status).when(response).getStatus();
+        assert(String.valueOf(status).equals(adapter.getResponseHttpStatus(response)));
+    }
+
+    @Test
+    public void getRequestHttpMethod() {
+        String method = "GET";
+        doReturn(method).when(request).getMethod();
+        assert(method.equals(adapter.getRequestHttpMethod(request)));
+    }
+}

--- a/wingtips-servlet-api/src/test/java/com/nike/wingtips/servlet/ServletRuntimeTest.java
+++ b/wingtips-servlet-api/src/test/java/com/nike/wingtips/servlet/ServletRuntimeTest.java
@@ -1,16 +1,12 @@
 package com.nike.wingtips.servlet;
 
-import com.nike.wingtips.servlet.ServletRuntime.Servlet2Runtime;
-import com.nike.wingtips.servlet.ServletRuntime.Servlet3Runtime;
-import com.nike.wingtips.util.TracingState;
-
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.io.IOException;
 import java.util.List;
@@ -22,13 +18,17 @@ import javax.servlet.DispatcherType;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
+import com.nike.wingtips.servlet.ServletRuntime.Servlet2Runtime;
+import com.nike.wingtips.servlet.ServletRuntime.Servlet3Runtime;
+import com.nike.wingtips.tags.HttpTagStrategy;
+import com.nike.wingtips.util.TracingState;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 
 /**
  * Tests the functionality of {@link ServletRuntime}.
@@ -118,7 +118,7 @@ public class ServletRuntimeTest {
     ) throws ServletException, IOException {
         // when
         Throwable ex = catchThrowable(
-            () -> servlet2Runtime.setupTracingCompletionWhenAsyncRequestCompletes(requestMock, mock(TracingState.class))
+            () -> servlet2Runtime.setupTracingCompletionWhenAsyncRequestCompletes(requestMock, mock(TracingState.class), mock(HttpTagStrategy.class))
         );
 
         // then
@@ -174,7 +174,7 @@ public class ServletRuntimeTest {
         ArgumentCaptor<AsyncListener> listenerCaptor = ArgumentCaptor.forClass(AsyncListener.class);
 
         // when
-        servlet3Runtime.setupTracingCompletionWhenAsyncRequestCompletes(requestMock, tracingStateMock);
+        servlet3Runtime.setupTracingCompletionWhenAsyncRequestCompletes(requestMock, tracingStateMock, null);
 
         // then
         verify(asyncContextMock).addListener(listenerCaptor.capture());

--- a/wingtips-spring-boot/README.md
+++ b/wingtips-spring-boot/README.md
@@ -31,7 +31,8 @@ And (optionally) specify configuration from your Spring Boot app's `application.
 ``` ini
 wingtips.wingtips-disabled=false
 wingtips.user-id-header-keys=userid,altuserid
-wingtips.span-logging-format=KEY_VALUE 
+wingtips.span-logging-format=KEY_VALUE
+wingtips.server-side-span-tag-strategy=ZIPKIN
 ```
 
 ## Feature details
@@ -49,6 +50,10 @@ features:
     `WingtipsSpringBootConfiguration` will use that one instead of creating a new default one.
     - Sets the span logging representation used by Wingtips to whatever you specify in your 
     `wingtips.span-logging-format` application property (see `WingtipsSpringBootProperties` description below).
+    - The `RequestTracingFilter` uses a `ServletRequestTagStrategy` to implement `OpenTracing` tags for `SERVER` 
+    requests.  To modify the tag strategy, supply a `@Bean` of type 
+    `HttpRequestResponseTagStrategy<HttpServletRequest, HttpServletResponse>` and it will be injected into the 
+    	`RequestTracingFilter`. 
 * **`WingtipsSpringBootProperties`** - The Spring Boot 
 [@ConfigurationProperties](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-typesafe-configuration-properties) 
 companion for `WingtipsSpringBootConfiguration` (described above) that allows you to customize some Wingtips behaviors 

--- a/wingtips-spring-boot/src/main/java/com/nike/wingtips/springboot/WingtipsSpringBootConfiguration.java
+++ b/wingtips-spring-boot/src/main/java/com/nike/wingtips/springboot/WingtipsSpringBootConfiguration.java
@@ -1,7 +1,15 @@
 package com.nike.wingtips.springboot;
 
-import com.nike.wingtips.Tracer;
-import com.nike.wingtips.servlet.RequestTracingFilter;
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
@@ -11,14 +19,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 
-import java.io.IOException;
-
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import com.nike.wingtips.Tracer;
+import com.nike.wingtips.servlet.RequestTracingFilter;
+import com.nike.wingtips.tags.HttpTagAdapter;
+import com.nike.wingtips.tags.HttpTagStrategy;
 
 /**
  * Wingtips Spring Boot configuration - this class enables Wingtips tracing on incoming requests by exposing a {@link
@@ -70,6 +74,9 @@ public class WingtipsSpringBootConfiguration {
 
     @SuppressWarnings("WeakerAccess")
     protected WingtipsSpringBootProperties wingtipsProperties;
+    
+    @Autowired(required = false)
+    protected HttpTagStrategy<HttpServletRequest, HttpServletResponse> tagStrategy;
 
     @Autowired
     public WingtipsSpringBootConfiguration(WingtipsSpringBootProperties wingtipsProperties) {
@@ -106,6 +113,12 @@ public class WingtipsSpringBootConfiguration {
         if (wingtipsProperties.getUserIdHeaderKeys() != null) {
             frb.addInitParameter(RequestTracingFilter.USER_ID_HEADER_KEYS_LIST_INIT_PARAM_NAME,
                                  wingtipsProperties.getUserIdHeaderKeys());
+        }
+        
+        // Add the tagging strategy to the filter
+        if (wingtipsProperties.getServerSideSpanTaggingStrategy() != null) {
+            frb.addInitParameter(RequestTracingFilter.TAG_STRATEGY_INIT_PARAM_NAME, 
+                    wingtipsProperties.getServerSideSpanTaggingStrategy());
         }
         // Set the order so that the tracing filter is registered first
         frb.setOrder(Ordered.HIGHEST_PRECEDENCE);

--- a/wingtips-spring-boot/src/main/java/com/nike/wingtips/springboot/WingtipsSpringBootProperties.java
+++ b/wingtips-spring-boot/src/main/java/com/nike/wingtips/springboot/WingtipsSpringBootProperties.java
@@ -25,6 +25,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *         {@link Tracer.SpanLoggingRepresentation} enum. Must be either JSON or KEY_VALUE. If missing then the span
  *         logging format will not be changed (defaults to JSON).
  *     </li>
+ *     <li>
+ *         wingtips.server-side-span-tagging-strategy - Determines the set of tags Wingtips will apply to spans. Represents the
+ *         {@link com.nike.wingtips.tag.HttpTagStrategy} implementation. Must be one of: ZIPKIN, OPENTRACING, or NONE. 
+ *         If missing then the default strategy will not be changed (defaults to OPENTRACING).
+ *     </li>
  * </ul>
  *
  * <p>For example you could set the following properties in your {@code application.properties}:
@@ -32,6 +37,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *     wingtips.wingtips-disabled=false
  *     wingtips.user-id-header-keys=userid,altuserid
  *     wingtips.span-logging-format=KEY_VALUE
+ *     wingtips.server-side-span-tagging-strategy=OPENTRACING
  * </pre>
  *
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
@@ -43,6 +49,7 @@ public class WingtipsSpringBootProperties {
     private boolean wingtipsDisabled = false;
     private String userIdHeaderKeys;
     private Tracer.SpanLoggingRepresentation spanLoggingFormat;
+    private String serverSideSpanTaggingStrategy;
 
     public boolean isWingtipsDisabled() {
         return wingtipsDisabled;
@@ -66,5 +73,13 @@ public class WingtipsSpringBootProperties {
 
     public void setSpanLoggingFormat(Tracer.SpanLoggingRepresentation spanLoggingFormat) {
         this.spanLoggingFormat = spanLoggingFormat;
+    }
+
+    public String getServerSideSpanTaggingStrategy() {
+        return serverSideSpanTaggingStrategy;
+    }
+
+    public void setServerSideSpanTaggingStrategy(String spanTaggingStrategy) {
+        this.serverSideSpanTaggingStrategy = spanTaggingStrategy;
     }
 }

--- a/wingtips-spring-boot/src/test/java/com/nike/wingtips/springboot/WingtipsSpringBootPropertiesTest.java
+++ b/wingtips-spring-boot/src/test/java/com/nike/wingtips/springboot/WingtipsSpringBootPropertiesTest.java
@@ -72,6 +72,15 @@ public class WingtipsSpringBootPropertiesTest {
             props.setSpanLoggingFormat(null);
             assertThat(props.getSpanLoggingFormat()).isNull();
         }
+        
+        // tagStrategy getter/setter
+        {
+            props.setServerSideSpanTaggingStrategy("OPENTRACING");
+            assertThat(props.getServerSideSpanTaggingStrategy()).isEqualTo("OPENTRACING");
+
+            props.setServerSideSpanTaggingStrategy(null);
+            assertThat(props.getServerSideSpanTaggingStrategy()).isNull();
+        }
     }
 
 }

--- a/wingtips-spring/src/main/java/com/nike/wingtips/spring/interceptor/tag/SpringHttpClientTagAdapter.java
+++ b/wingtips-spring/src/main/java/com/nike/wingtips/spring/interceptor/tag/SpringHttpClientTagAdapter.java
@@ -1,0 +1,67 @@
+package com.nike.wingtips.spring.interceptor.tag;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+
+import com.nike.wingtips.tags.HttpTagAdapter;
+
+public class SpringHttpClientTagAdapter implements HttpTagAdapter<HttpRequest, ClientHttpResponse>{
+
+    /**
+     * @return true if the current {@code Span} should be tagged as having an errd state. This defaults to return true
+     * if the response status code is &gt;= 500.  
+     * 
+     * Both the {@code HttpRequest} and {@code ClientHttpResponse} are provided for inspection for other 
+     * subclass implementation overrides.
+     *  
+     * @param response - {@code ClientHttpResponse}
+     * @throws IOException - in case of I/O errors while pulling the response status code
+     */
+    @Override
+    public boolean isErrorResponse(ClientHttpResponse response) {
+        try {
+            return response.getRawStatusCode() >= 500;
+        } catch (IOException ioe) {
+            return true;
+        }
+    }
+
+    /**
+     * @return The value for the {@code http.url} tag.  The default is to use the full URL.{@code request.getURI().toString()}. 
+     * 
+     * @param request - The {@code HttpRequest}
+     * @throws IOException - in case of I/O errors while pulling the request URI
+     */
+    @Override
+    public String getRequestUrl(HttpRequest request) {
+        try {
+            return request.getURI().toURL().toString();
+        } catch(MalformedURLException exception) {
+            // Return the abbreviated version if it can't be converted to a full url
+            return request.getURI().toString();
+        }
+    }
+
+    @Override
+    public String getResponseHttpStatus(ClientHttpResponse response) {
+        try {
+            return String.valueOf(response.getRawStatusCode());
+        } catch(IOException ioe) {
+            return "IOException";
+        }
+    }
+
+    @Override
+    public String getRequestHttpMethod(HttpRequest request) {
+        return request.getMethod().name();
+    }
+
+    @Override
+    public String getRequestUri(HttpRequest request) {
+        return request.getURI().getPath();
+    }
+
+}

--- a/wingtips-spring/src/main/java/com/nike/wingtips/spring/util/WingtipsSpringUtil.java
+++ b/wingtips-spring/src/main/java/com/nike/wingtips/spring/util/WingtipsSpringUtil.java
@@ -9,11 +9,14 @@ import com.nike.wingtips.spring.interceptor.WingtipsClientHttpRequestInterceptor
 import com.nike.wingtips.spring.util.asynchelperwrapper.FailureCallbackWithTracing;
 import com.nike.wingtips.spring.util.asynchelperwrapper.ListenableFutureCallbackWithTracing;
 import com.nike.wingtips.spring.util.asynchelperwrapper.SuccessCallbackWithTracing;
+import com.nike.wingtips.tags.HttpTagStrategy;
 import com.nike.wingtips.util.TracingState;
 
 import org.slf4j.MDC;
 import org.springframework.http.HttpMessage;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.util.concurrent.ListenableFutureCallback;
 import org.springframework.util.concurrent.SuccessCallback;
@@ -63,6 +66,20 @@ public class WingtipsSpringUtil {
         );
         return restTemplate;
     }
+    
+    /**
+     * @param tagStrategy The tagging strategy to be used to tag request/response metadata to the subspan
+     * @return A new {@link RestTemplate} instance with a {@link WingtipsClientHttpRequestInterceptor}
+     * already added and with the subspan option on and a {@code HttpTagStrategy} for appending the request/response metadata
+     * to the subspan
+     */
+    public static RestTemplate createTracingEnabledRestTemplate(HttpTagStrategy<HttpRequest, ClientHttpResponse> tagStrategy) {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getInterceptors().add(
+            new WingtipsClientHttpRequestInterceptor(true, tagStrategy)
+        );
+        return restTemplate;
+    }
 
     /**
      * @return A new {@link AsyncRestTemplate} instance with a {@link WingtipsAsyncClientHttpRequestInterceptor}
@@ -84,6 +101,20 @@ public class WingtipsSpringUtil {
         AsyncRestTemplate asyncRestTemplate = new AsyncRestTemplate();
         asyncRestTemplate.getInterceptors().add(
             new WingtipsAsyncClientHttpRequestInterceptor(surroundCallsWithSubspan)
+        );
+        return asyncRestTemplate;
+    }
+    
+    /**
+     * @param tagStrategy The tagging strategy to be used to tag request/response metadata to the subspan
+     * @return A new {@link AsyncRestTemplate} instance with a {@link WingtipsAsyncClientHttpRequestInterceptor}
+     * already added and with the subspan option on and a tag strategy for appending the request/response metadata
+     * to the subspan
+     */
+    public static AsyncRestTemplate createTracingEnabledAsyncRestTemplate(HttpTagStrategy<HttpRequest, ClientHttpResponse> tagStrategy) {
+        AsyncRestTemplate asyncRestTemplate = new AsyncRestTemplate();
+        asyncRestTemplate.getInterceptors().add(
+            new WingtipsAsyncClientHttpRequestInterceptor(true, tagStrategy)
         );
         return asyncRestTemplate;
     }

--- a/wingtips-spring/src/main/java/com/nike/wingtips/spring/util/asynchelperwrapper/SuccessCallbackWithTracing.java
+++ b/wingtips-spring/src/main/java/com/nike/wingtips/spring/util/asynchelperwrapper/SuccessCallbackWithTracing.java
@@ -1,4 +1,4 @@
-package com.nike.wingtips.spring.util.asynchelperwrapper;
+ package com.nike.wingtips.spring.util.asynchelperwrapper;
 
 import com.nike.internal.util.Pair;
 import com.nike.wingtips.Span;

--- a/wingtips-spring/src/test/java/com/nike/wingtips/spring/interceptor/WingtipsClientHttpRequestInterceptorTest.java
+++ b/wingtips-spring/src/test/java/com/nike/wingtips/spring/interceptor/WingtipsClientHttpRequestInterceptorTest.java
@@ -5,6 +5,8 @@ import com.nike.wingtips.Span.SpanPurpose;
 import com.nike.wingtips.Tracer;
 import com.nike.wingtips.spring.testutils.TestUtils.SpanRecorder;
 import com.nike.wingtips.spring.util.HttpRequestWrapperWithModifiableHeaders;
+import com.nike.wingtips.tags.HttpTagStrategy;
+import com.nike.wingtips.tags.KnownOpenTracingTags;
 import com.nike.wingtips.util.TracingState;
 
 import com.tngtech.java.junit.dataprovider.DataProvider;
@@ -18,9 +20,12 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpResponse;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.UUID;
 
@@ -34,6 +39,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -51,6 +57,8 @@ public class WingtipsClientHttpRequestInterceptorTest {
     private URI uri;
 
     private byte[] body;
+    private ClientHttpResponse response;
+    private HttpStatus httpResponseStatus;
     private ClientHttpRequestExecution executionMock;
 
     private SpanRecorder spanRecorder;
@@ -81,10 +89,27 @@ public class WingtipsClientHttpRequestInterceptorTest {
         };
 
         body = UUID.randomUUID().toString().getBytes();
+
+        response = new ClientHttpResponse() {
+
+            @Override public InputStream getBody() throws IOException { return null; }
+
+            @Override public HttpHeaders getHeaders() { return null; }
+
+            @Override public HttpStatus getStatusCode() throws IOException { return httpResponseStatus; }
+
+            @Override public int getRawStatusCode() throws IOException { return httpResponseStatus.value(); }
+
+            @Override public String getStatusText() throws IOException { return httpResponseStatus.toString(); }
+
+            @Override public void close() {}
+
+        };
+
         executionMock = mock(ClientHttpRequestExecution.class);
         doAnswer(invocation -> {
             tracingStateAtTimeOfExecution = TracingState.getCurrentThreadTracingState();
-            return null;
+            return response;
         }).when(executionMock).execute(any(HttpRequest.class), any(byte[].class));
     }
 
@@ -103,13 +128,13 @@ public class WingtipsClientHttpRequestInterceptorTest {
     }
 
     @DataProvider(value = {
-        "true",
-        "false"
+            "true",
+            "false"
     })
     @Test
     public void single_arg_constructor_creates_instance_with_subspan_option_set_to_desired_value(
-        boolean subspanOptionOn
-    ) {
+            boolean subspanOptionOn
+            ) {
         // when
         WingtipsClientHttpRequestInterceptor interceptor = new WingtipsClientHttpRequestInterceptor(subspanOptionOn);
 
@@ -136,19 +161,35 @@ public class WingtipsClientHttpRequestInterceptorTest {
     }
 
     @DataProvider(value = {
-        "true   |   true",
-        "true   |   false",
-        "false  |   true",
-        "false  |   false"
+            "true   |   true   | OK",
+            "true   |   true   | INTERNAL_SERVER_ERROR",
+            "true   |   false  | OK",
+            "true   |   false  | INTERNAL_SERVER_ERROR",
+            "false  |   true   | OK",
+            "false  |   true   | INTERNAL_SERVER_ERROR",
+            "false  |   false  | OK",
+            "false  |   false  | INTERNAL_SERVER_ERROR"
     }, splitBy = "\\|")
     @Test
     public void intercept_works_as_expected(
-        boolean currentSpanExists, boolean subspanOptionOn
-    ) throws IOException {
+            boolean currentSpanExists, boolean subspanOptionOn, HttpStatus responseStatus
+            ) throws IOException {
+        // when
+        this.httpResponseStatus = responseStatus;
+        boolean tagsExpected = true;
+
         // given
         WingtipsClientHttpRequestInterceptor interceptor = new WingtipsClientHttpRequestInterceptor(subspanOptionOn);
+        
+        // then
+        execute_and_validate_intercept_worked_as_expected(interceptor, currentSpanExists, subspanOptionOn, responseStatus, tagsExpected);
+    }
+    
+    public void execute_and_validate_intercept_worked_as_expected(
+            WingtipsClientHttpRequestInterceptor interceptor, boolean currentSpanExists, boolean subspanOptionOn, HttpStatus responseStatus, boolean tagsExpected
+            ) throws IOException  {
         Span rootSpan = (currentSpanExists)
-                        ? Tracer.getInstance().startRequestWithRootSpan("rootSpan")
+                ? Tracer.getInstance().startRequestWithRootSpan("rootSpan")
                         : null;
 
         // Tracing info should be propagated on the headers if a current span exists when the interceptor is called,
@@ -171,7 +212,7 @@ public class WingtipsClientHttpRequestInterceptorTest {
         // The tracing headers should be set on the request based on what the tracing state was at the time of execution
         //      (which depends on whether the subspan option was on, which we'll get to later).
         Span expectedSpanForHeaders = getExpectedSpanForHeaders(expectTracingInfoPropagation,
-                                                                tracingStateAtTimeOfExecution);
+                tracingStateAtTimeOfExecution);
         verifyExpectedTracingHeaders(executedRequest, expectedSpanForHeaders);
 
         if (subspanOptionOn) {
@@ -196,6 +237,20 @@ public class WingtipsClientHttpRequestInterceptorTest {
 
             // The completed span should have been a CLIENT span.
             assertThat(completedSpan.getSpanPurpose()).isEqualTo(SpanPurpose.CLIENT);
+
+            if (tagsExpected) {
+                // The completed span has the appropriate tags
+                assertThat(completedSpan.getTags().get(KnownOpenTracingTags.HTTP_METHOD)).isEqualTo(method.toString());
+                assertThat(completedSpan.getTags().get(KnownOpenTracingTags.HTTP_URL)).isEqualTo(uri.toURL().toString());
+                assertThat(completedSpan.getTags().get(KnownOpenTracingTags.HTTP_STATUS)).isEqualTo(String.valueOf(httpResponseStatus.value()));
+    
+                //Default behavior is to mark span as err'd if response code >= 500
+                if(httpResponseStatus.is5xxServerError()) {
+                    assertThat(completedSpan.getTags().get(KnownOpenTracingTags.ERROR)).isEqualTo(Boolean.TRUE.toString());
+                } else {
+                    assertThat(completedSpan.getTags().get(KnownOpenTracingTags.ERROR)).isNull();
+                }
+            }
         }
         else {
             // The subspan option was turned off, so we should *not* have any completed spans, and the tracing state
@@ -214,77 +269,107 @@ public class WingtipsClientHttpRequestInterceptorTest {
                 assertThat(tracingStateAtTimeOfExecution.spanStack).isNullOrEmpty();
             }
         }
-        
+
         // After all is said and done, we should end up with the same tracing state as when we called the interceptor.
         assertThat(normalizeTracingState(TracingState.getCurrentThreadTracingState()))
-            .isEqualTo(normalizeTracingState(tracingStateBeforeInterceptorCall));
+        .isEqualTo(normalizeTracingState(tracingStateBeforeInterceptorCall));
     }
 
     @DataProvider(value = {
-        "true   |   true",
-        "true   |   false",
-        "false  |   true",
-        "false  |   false"
+            "true   |   true",
+            "true   |   false",
+            "false  |   true",
+            "false  |   false"
     }, splitBy = "\\|")
     @Test
     public void intercept_handles_span_closing_logic_even_if_execution_explodes(
-        boolean currentSpanExists, boolean subspanOptionOn
-    ) throws IOException {
+            boolean currentSpanExists, boolean subspanOptionOn
+            ) throws IOException {
         // given
         WingtipsClientHttpRequestInterceptor interceptor = new WingtipsClientHttpRequestInterceptor(subspanOptionOn);
         Span rootSpan = (currentSpanExists)
-                        ? Tracer.getInstance().startRequestWithRootSpan("rootSpan")
+                ? Tracer.getInstance().startRequestWithRootSpan("rootSpan")
                         : null;
 
-        TracingState tracingStateBeforeInterceptorCall = TracingState.getCurrentThreadTracingState();
+                TracingState tracingStateBeforeInterceptorCall = TracingState.getCurrentThreadTracingState();
 
-        RuntimeException executionExplosion = new RuntimeException("kaboom");
-        doAnswer(invocation -> {
-            tracingStateAtTimeOfExecution = TracingState.getCurrentThreadTracingState();
-            throw executionExplosion;
-        }).when(executionMock).execute(any(HttpRequest.class), any(byte[].class));
+                RuntimeException executionExplosion = new RuntimeException("kaboom");
+                doAnswer(invocation -> {
+                    tracingStateAtTimeOfExecution = TracingState.getCurrentThreadTracingState();
+                    throw executionExplosion;
+                }).when(executionMock).execute(any(HttpRequest.class), any(byte[].class));
 
+                // when
+                Throwable ex = catchThrowable(() -> interceptor.intercept(httpRequest, body, executionMock));
+
+                // then
+                assertThat(ex).isSameAs(executionExplosion);
+
+                if (subspanOptionOn) {
+                    // The subspan option was on so we should have a span that was completed.
+                    assertThat(spanRecorder.completedSpans).hasSize(1);
+                    Span completedSpan = spanRecorder.completedSpans.get(0);
+
+                    if (currentSpanExists) {
+                        // A span was already on the stack when the interceptor was called, so the completed span should be
+                        //      a subspan of the root span.
+                        assertThat(completedSpan.getTraceId()).isEqualTo(rootSpan.getTraceId());
+                        assertThat(completedSpan.getParentSpanId()).isEqualTo(rootSpan.getSpanId());
+                    }
+                    else {
+                        // There was no span on the stack when the interceptor was called, so the completed span should itself
+                        //      be a root span.
+                        assertThat(completedSpan.getParentSpanId()).isNull();
+                    }
+
+                    // The completed span should have been a CLIENT span.
+                    assertThat(completedSpan.getSpanPurpose()).isEqualTo(SpanPurpose.CLIENT);
+
+                    // Tag the span as error when execution explodes
+                    assertThat(completedSpan.getTags().get(KnownOpenTracingTags.ERROR)).isEqualTo(Boolean.TRUE.toString());
+
+                    // The request tags should be present
+                    assertThat(completedSpan.getTags().get(KnownOpenTracingTags.HTTP_METHOD)).isEqualTo(method.toString());
+                    assertThat(completedSpan.getTags().get(KnownOpenTracingTags.HTTP_URL)).isEqualTo(uri.toURL().toString());
+                }
+                else {
+                    // The subspan option was turned off, so we should *not* have any completed spans, and the tracing state
+                    //      at time of execution should be the same as when the interceptor was called.
+                    assertThat(spanRecorder.completedSpans).isEmpty();
+                    assertThat(tracingStateAtTimeOfExecution).isEqualTo(tracingStateBeforeInterceptorCall);
+                }
+
+                // After all is said and done, we should end up with the same tracing state as when we called the interceptor.
+                assertThat(normalizeTracingState(TracingState.getCurrentThreadTracingState()))
+                .isEqualTo(normalizeTracingState(tracingStateBeforeInterceptorCall));
+    }
+    
+    @DataProvider(value = {
+        "OK",
+        "INTERNAL_SERVER_ERROR"
+    })
+    @Test
+    public void intercept_works_when_tagstrategy_explodes(HttpStatus responseStatus) throws IOException {
         // when
-        Throwable ex = catchThrowable(() -> interceptor.intercept(httpRequest, body, executionMock));
+        this.httpResponseStatus = responseStatus;
+        boolean tagsExpected = false; // We don't expect any tags present
+        boolean subspanOptionOn = true; // Required to be true for the tag strategy to be used
+        boolean currentSpanExists = false;  // We're indifferent on this value
+        HttpTagStrategy<HttpRequest, ClientHttpResponse> explodingTagStrategy = mock(HttpTagStrategy.class);
+        doThrow(new RuntimeException("boom")).when(explodingTagStrategy).tagSpanWithRequestAttributes(any(Span.class), any(HttpRequest.class));
+        doThrow(new RuntimeException("boom")).when(explodingTagStrategy).tagSpanWithResponseAttributes(any(Span.class), any(ClientHttpResponse.class));
+        doThrow(new RuntimeException("boom")).when(explodingTagStrategy).handleErroredRequest(any(Span.class), any(Throwable.class));
 
+        // given
+        WingtipsClientHttpRequestInterceptor interceptor = new WingtipsClientHttpRequestInterceptor(subspanOptionOn, explodingTagStrategy);
+        
         // then
-        assertThat(ex).isSameAs(executionExplosion);
-
-        if (subspanOptionOn) {
-            // The subspan option was on so we should have a span that was completed.
-            assertThat(spanRecorder.completedSpans).hasSize(1);
-            Span completedSpan = spanRecorder.completedSpans.get(0);
-
-            if (currentSpanExists) {
-                // A span was already on the stack when the interceptor was called, so the completed span should be
-                //      a subspan of the root span.
-                assertThat(completedSpan.getTraceId()).isEqualTo(rootSpan.getTraceId());
-                assertThat(completedSpan.getParentSpanId()).isEqualTo(rootSpan.getSpanId());
-            }
-            else {
-                // There was no span on the stack when the interceptor was called, so the completed span should itself
-                //      be a root span.
-                assertThat(completedSpan.getParentSpanId()).isNull();
-            }
-
-            // The completed span should have been a CLIENT span.
-            assertThat(completedSpan.getSpanPurpose()).isEqualTo(SpanPurpose.CLIENT);
-        }
-        else {
-            // The subspan option was turned off, so we should *not* have any completed spans, and the tracing state
-            //      at time of execution should be the same as when the interceptor was called.
-            assertThat(spanRecorder.completedSpans).isEmpty();
-            assertThat(tracingStateAtTimeOfExecution).isEqualTo(tracingStateBeforeInterceptorCall);
-        }
-
-        // After all is said and done, we should end up with the same tracing state as when we called the interceptor.
-        assertThat(normalizeTracingState(TracingState.getCurrentThreadTracingState()))
-            .isEqualTo(normalizeTracingState(tracingStateBeforeInterceptorCall));
+        execute_and_validate_intercept_worked_as_expected(interceptor, currentSpanExists, subspanOptionOn, responseStatus, tagsExpected);
     }
 
     @DataProvider(value = {
-        "true",
-        "false"
+            "true",
+            "false"
     })
     @Test
     public void getSubspanSpanName_works_as_expected(boolean includeQueryString) {

--- a/wingtips-zipkin2-spring-boot/README.md
+++ b/wingtips-zipkin2-spring-boot/README.md
@@ -37,6 +37,7 @@ highly recommended that you also at least specify `wingtips.zipkin.service-name`
 wingtips.wingtips-disabled=false
 wingtips.user-id-header-keys=userid,altuserid
 wingtips.span-logging-format=KEY_VALUE 
+wingtips.server-side-span-tagging-strategy=ZIPKIN
 
 # Zipkin integration config for Wingtips
 wingtips.zipkin.zipkin-disabled=false


### PR DESCRIPTION
Added default tags for every request that comes through the filter. Also split out some functions that might want to be overridden:
- What determines an error tag to be set to true
- The human-readable name for a `Span`
- The URI/URL pattern used as the value for http.url