### PR TITLE
Escape commas in tag keys when serializing Spans in key/value format

### DIFF
--- a/wingtips-core/src/main/java/com/nike/wingtips/util/parser/SpanParser.java
+++ b/wingtips-core/src/main/java/com/nike/wingtips/util/parser/SpanParser.java
@@ -98,8 +98,8 @@ public class SpanParser {
     public static final String KEY_VALUE_TAG_PREFIX = "tag_";
 
     /**
-     * The prefix that will be added to every {@link Span#getTimestampedAnnotations()} tag key when serializing a
-     * {@link Span} to key/value format. See {@link #convertSpanToKeyValueFormat(Span)}.
+     * The prefix that will be added to every {@link Span#getTimestampedAnnotations()} annotation key (the timestamp)
+     * when serializing a {@link Span} to key/value format. See {@link #convertSpanToKeyValueFormat(Span)}.
      */
     public static final String KEY_VALUE_TIMESTAMPED_ANNOTATION_PREFIX = "ts_annot_";
 
@@ -535,11 +535,19 @@ public class SpanParser {
         if (containsChar(escapedKey, ' ')) {
             escapedKey = escapedKey.replace(" ", ESCAPED_SPACE_CHAR);
         }
+        // And comma character.
+        if (containsChar(escapedKey, ',')) {
+            escapedKey = escapedKey.replace(",", ESCAPED_COMMA_CHAR);
+        }
         return escapedKey;
     }
 
     protected static String unescapeTagKeyForKeyValueFormatDeserialization(String escapedKey) {
         // Do the reverse of the escape-tag logic.
+        if (escapedKey.contains(ESCAPED_COMMA_CHAR)) {
+            escapedKey = escapedKey.replace(ESCAPED_COMMA_CHAR, ",");
+        }
+
         if (escapedKey.contains(ESCAPED_SPACE_CHAR)) {
             escapedKey = escapedKey.replace(ESCAPED_SPACE_CHAR, " ");
         }
@@ -878,6 +886,7 @@ public class SpanParser {
     protected static final String[] JSON_ESCAPE_CHAR_MAPPINGS;
     protected static final String ESCAPED_EQUALS_SIGN = "\\u003D";
     protected static final String ESCAPED_SPACE_CHAR = "\\u0020";
+    protected static final String ESCAPED_COMMA_CHAR = "\\u002C";
     static {
         String[] jsonEscapeCharMappings = new String[128];
 

--- a/wingtips-core/src/test/java/com/nike/wingtips/util/parser/SpanParserTest.java
+++ b/wingtips-core/src/test/java/com/nike/wingtips/util/parser/SpanParserTest.java
@@ -1116,12 +1116,12 @@ public class SpanParserTest {
     @Test
     public void convertSpanToKeyValueFormat_and_fromKeyValueString_escapes_and_unescapes_tag_keys_as_expected() {
         // given
-        String unescapedTagKey = "fookey=blah withspace";
+        String unescapedTagKey = "fookey=blah withspaceandequals,andcomma";
         String tagValue = UUID.randomUUID().toString();
         Span span = Span.newBuilder("someSpan", SpanPurpose.CLIENT)
                         .withTag(unescapedTagKey, tagValue)
                         .build();
-        String expectedEscapedTagKey = "fookey\\u003Dblah\\u0020withspace";
+        String expectedEscapedTagKey = "fookey\\u003Dblah\\u0020withspaceandequals\\u002Candcomma";
 
         // when
         String keyValueStr = SpanParser.convertSpanToKeyValueFormat(span);


### PR DESCRIPTION
This is necessary to make parsing of key-value-serialized-Spans a reasonable task, as unquoted commas are a special character that separates key/value pairs.