### PR TITLE
Makes Span implement Serializable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ ext {
     junitDataproviderVersion = '1.10.1'
     restAssuredVersion = '3.0.1'
     apacheCommonsIoVersion = '2.5'
+    apacheCommonsLangVersion = '2.6'
 
     jettyVersion = '9.3.21.v20170918'
 

--- a/wingtips-core/build.gradle
+++ b/wingtips-core/build.gradle
@@ -21,6 +21,7 @@ dependencies {
             "ch.qos.logback:logback-classic:$logbackVersion",
             "org.assertj:assertj-core:$assertJVersion",
             "com.tngtech.java:junit-dataprovider:$junitDataproviderVersion",
-            "org.jetbrains:annotations:$jetbrainsAnnotationsVersion"
+            "org.jetbrains:annotations:$jetbrainsAnnotationsVersion",
+            "commons-lang:commons-lang:$apacheCommonsLangVersion"
     )
 }

--- a/wingtips-core/src/main/java/com/nike/wingtips/Span.java
+++ b/wingtips-core/src/main/java/com/nike/wingtips/Span.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -50,7 +51,7 @@ import java.util.concurrent.TimeUnit;
  * @author Nic Munroe
  */
 @SuppressWarnings("WeakerAccess")
-public class Span implements Closeable {
+public class Span implements Closeable, Serializable {
 
     private final String traceId;
     private final String spanId;
@@ -616,7 +617,7 @@ public class Span implements Closeable {
      * <p>The timestamp is retrieved via {@link #getTimestampEpochMicros()}, and the value associated with that
      * timestamp is retrieved via {@link #getValue()}.
      */
-    public static class TimestampedAnnotation {
+    public static class TimestampedAnnotation implements Serializable {
 
         private final long timestampEpochMicros;
         private final String value;

--- a/wingtips-core/src/test/java/com/nike/wingtips/SpanTest.java
+++ b/wingtips-core/src/test/java/com/nike/wingtips/SpanTest.java
@@ -12,6 +12,7 @@ import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 
 import org.assertj.core.data.Offset;
+import org.apache.commons.lang.SerializationUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -1506,5 +1507,18 @@ public class SpanTest {
         assertThat(result.getTimestampEpochMicros()).isEqualTo(expectedTimestamp);
         assertThat(result.getValue()).isEqualTo(value);
     }
-}
 
+    @Test
+    public void span_serializes_and_deserializes_with_no_data_loss() {
+        Span span = new Span(
+            traceId, parentSpanId, spanId, spanName, sampleableForFullyCompleteSpan, userId,
+            spanPurposeForFullyCompletedSpan, startTimeEpochMicrosForFullyCompleteSpan,
+            startTimeNanosForFullyCompleteSpan, durationNanosForFullyCompletedSpan, tags, annotations
+        );
+
+        byte[] bytes = SerializationUtils.serialize(span);
+        Span deserializedSpan = (Span) SerializationUtils.deserialize(bytes);
+
+        verifySpanDeepEquals(span, deserializedSpan, false);
+    }
+}


### PR DESCRIPTION
I'm not sure if this has any negative side effects but I'm attempting to use a Span as part of a Flink stream and all data members have to be serializable. Without this PR, I'm required to wrap Span in a Serializable class (more likely just wrap the string representation) that can convert to and from a Span.

Please let me know if there's anything else that's needed.