### PR TITLE
Reduce log spam

### DIFF
--- a/wingtips-lightstep/src/main/java/com/nike/wingtips/lightstep/WingtipsToLightStepLifecycleListener.java
+++ b/wingtips-lightstep/src/main/java/com/nike/wingtips/lightstep/WingtipsToLightStepLifecycleListener.java
@@ -34,13 +34,12 @@ import static java.util.Objects.requireNonNull;
  * @author parker@lightstep.com
  */
 
+@SuppressWarnings("WeakerAccess")
 public class WingtipsToLightStepLifecycleListener implements SpanLifecycleListener {
 
     // we borrowed the logging and exception log rate limiting from the Zipkin plugin.
     private final Logger lightStepToWingtipsLogger =
         LoggerFactory.getLogger("LIGHTSTEP_SPAN_CONVERSION_OR_HANDLING_ERROR");
-
-    private static final String SANITIZED_ID_LOG_MSG = "Detected invalid ID format. orig_id={}, sanitized_id={}";
 
     private final AtomicLong spanHandlingErrorCounter = new AtomicLong(0);
     private long lastSpanHandlingErrorLogTimeEpochMillis = 0;
@@ -59,13 +58,11 @@ public class WingtipsToLightStepLifecycleListener implements SpanLifecycleListen
         this(buildJreTracerFromOptions(serviceName, accessToken, satelliteUrl, satellitePort));
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     public WingtipsToLightStepLifecycleListener(@NotNull JRETracer tracer) {
         requireNonNull(tracer, "tracer cannot be null.");
         this.tracer = tracer;
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     private static @NotNull JRETracer buildJreTracerFromOptions(
         @NotNull String serviceName,
         @NotNull String accessToken,
@@ -159,12 +156,15 @@ public class WingtipsToLightStepLifecycleListener implements SpanLifecycleListen
             //      available via the wingtips.*_id tags.
             if (!wtSanitizedSpanId.equals(wingtipsSpan.getSpanId())) {
                 lsSpan.setTag("wingtips.span_id.invalid", true);
+                wingtipsSpan.putTag("sanitized_span_id", wtSanitizedSpanId);
             }
             if (!wtSanitizedTraceId.equals(wingtipsSpan.getTraceId())) {
                 lsSpan.setTag("wingtips.trace_id.invalid", true);
+                wingtipsSpan.putTag("sanitized_trace_id", wtSanitizedTraceId);
             }
             if (wtSanitizedParentId != null && !wtSanitizedParentId.equals(wingtipsSpan.getParentSpanId())) {
                 lsSpan.setTag("wingtips.parent_id.invalid", true);
+                wingtipsSpan.putTag("sanitized_parent_id", wtSanitizedParentId);
             }
 
             // on finish, the tracer library initialized on the creation of this listener will cache and transport the span
@@ -210,18 +210,14 @@ public class WingtipsToLightStepLifecycleListener implements SpanLifecycleListen
             else if (isHex(originalId, true)) {
                 // It wasn't lowerhex, but it is hex and it is the correct number of chars.
                 //      We can trivially convert to valid lowerhex by lowercasing the ID.
-                String sanitizedId = originalId.toLowerCase();
-                lightStepToWingtipsLogger.info(SANITIZED_ID_LOG_MSG, originalId, sanitizedId);
-                return sanitizedId;
+                return originalId.toLowerCase();
             }
         }
 
         // If the originalId can be parsed as a long, then its sanitized ID is the lowerhex representation of that long.
         Long originalIdAsRawLong = attemptToConvertToLong(originalId);
         if (originalIdAsRawLong != null) {
-            String sanitizedId = TraceAndSpanIdGenerator.longToUnsignedLowerHexString(originalIdAsRawLong);
-            lightStepToWingtipsLogger.info(SANITIZED_ID_LOG_MSG, originalId, sanitizedId);
-            return sanitizedId;
+            return TraceAndSpanIdGenerator.longToUnsignedLowerHexString(originalIdAsRawLong);
         }
 
         // If the originalId can be parsed as a UUID and is allowed to be 128 bit,
@@ -229,7 +225,6 @@ public class WingtipsToLightStepLifecycleListener implements SpanLifecycleListen
         if (allow128Bit) {
             String sanitizedId = attemptToSanitizeAsUuid(originalId);
             if (sanitizedId != null) {
-                lightStepToWingtipsLogger.info(SANITIZED_ID_LOG_MSG, originalId, sanitizedId);
                 return sanitizedId;
             }
         }
@@ -241,9 +236,7 @@ public class WingtipsToLightStepLifecycleListener implements SpanLifecycleListen
         //      ("TRUNCATION OF A MESSAGE DIGEST") here:
         //      https://csrc.nist.gov/csrc/media/publications/fips/180/4/final/documents/fips180-4-draft-aug2014.pdf
         int allowedNumChars = allow128Bit ? 32 : 16;
-        String sanitizedId = DigestUtils.sha256Hex(originalId).toLowerCase().substring(0, allowedNumChars);
-        lightStepToWingtipsLogger.info(SANITIZED_ID_LOG_MSG, originalId, sanitizedId);
-        return sanitizedId;
+        return DigestUtils.sha256Hex(originalId).toLowerCase().substring(0, allowedNumChars);
     }
 
     protected boolean isLowerHex(String id) {

--- a/wingtips-lightstep/src/main/java/com/nike/wingtips/lightstep/WingtipsToLightStepLifecycleListener.java
+++ b/wingtips-lightstep/src/main/java/com/nike/wingtips/lightstep/WingtipsToLightStepLifecycleListener.java
@@ -80,7 +80,7 @@ public class WingtipsToLightStepLifecycleListener implements SpanLifecycleListen
                     .withComponentName(serviceName)
                     .withCollectorHost(satelliteUrl)
                     .withCollectorPort(satellitePort)
-                    .withVerbosity(4)
+                    .withVerbosity(1)
                     .build()
             );
         } catch (Exception ex) {

--- a/wingtips-zipkin2/src/test/java/com/nike/wingtips/zipkin2/util/WingtipsToZipkinSpanConverterDefaultImplTest.java
+++ b/wingtips-zipkin2/src/test/java/com/nike/wingtips/zipkin2/util/WingtipsToZipkinSpanConverterDefaultImplTest.java
@@ -345,9 +345,15 @@ public class WingtipsToZipkinSpanConverterDefaultImplTest {
                 .withDurationNanos(Math.abs(random.nextLong()))
                 .build();
 
-        String expectedZipkinInvalidIdTagValue = (scenario.expectedSanitizedResultForTraceId.equals(scenario.originalId))
-                                                 ? null
-                                                 : scenario.originalId;
+        String expectedZipkinInvalidIdTagValue =
+            (scenario.expectedSanitizedResultForTraceId.equals(scenario.originalId))
+            ? null // no tag if sanitization wasn't needed
+            : scenario.originalId;
+
+        String expectedWingtipsSanitizedIdTagValue =
+            (scenario.expectedSanitizedResultForTraceId.equals(scenario.originalId))
+            ? null // no tag if sanitization wasn't needed
+            : scenario.expectedSanitizedResultForTraceId;
 
         // when
         zipkin2.Span zipkinSpan = impl.convertWingtipsSpanToZipkinSpan(wingtipsSpan, zipkinEndpoint);
@@ -355,6 +361,7 @@ public class WingtipsToZipkinSpanConverterDefaultImplTest {
         // then
         assertThat(zipkinSpan.traceId()).isEqualTo(scenario.expectedSanitizedResultForTraceId);
         assertThat(zipkinSpan.tags().get("invalid.trace_id")).isEqualTo(expectedZipkinInvalidIdTagValue);
+        assertThat(wingtipsSpan.getTags().get("sanitized_trace_id")).isEqualTo(expectedWingtipsSanitizedIdTagValue);
     }
 
     @UseDataProvider("idSanitizationScenarios")
@@ -377,6 +384,7 @@ public class WingtipsToZipkinSpanConverterDefaultImplTest {
         // then
         assertThat(zipkinSpan.id()).isEqualTo(scenario.expectedSanitizedResultForSpanIdOrParentSpanId);
         assertThat(zipkinSpan.tags().get("invalid.span_id")).isEqualTo(scenario.originalId);
+        assertThat(wingtipsSpan.getTags().get("sanitized_span_id")).isEqualTo(scenario.expectedSanitizedResultForSpanIdOrParentSpanId);
     }
 
     @UseDataProvider("idSanitizationScenarios")
@@ -399,6 +407,7 @@ public class WingtipsToZipkinSpanConverterDefaultImplTest {
         // then
         assertThat(zipkinSpan.parentId()).isEqualTo(scenario.expectedSanitizedResultForSpanIdOrParentSpanId);
         assertThat(zipkinSpan.tags().get("invalid.parent_id")).isEqualTo(scenario.originalId);
+        assertThat(wingtipsSpan.getTags().get("sanitized_parent_id")).isEqualTo(scenario.expectedSanitizedResultForSpanIdOrParentSpanId);
     }
 
     @Test
@@ -438,6 +447,9 @@ public class WingtipsToZipkinSpanConverterDefaultImplTest {
         assertThat(zipkinSpan.tags().get("invalid.trace_id")).isEqualTo(badTraceId);
         assertThat(zipkinSpan.tags().get("invalid.span_id")).isEqualTo(badSpanId);
         assertThat(zipkinSpan.tags().get("invalid.parent_id")).isEqualTo(badParentSpanId);
+        assertThat(wingtipsSpan.getTags().get("sanitized_trace_id")).isEqualTo(expectedSanitizedTraceId);
+        assertThat(wingtipsSpan.getTags().get("sanitized_span_id")).isEqualTo(expectedSanitizedSpanId);
+        assertThat(wingtipsSpan.getTags().get("sanitized_parent_id")).isEqualTo(expectedSanitizedParentSpanId);
     }
 
     @UseDataProvider("idSanitizationScenarios")


### PR DESCRIPTION
With the change to `Tracer` to notify `SpanLifecycleListener`s of completed spans before logging them, we can adjust `WingtipsToZipkinSpanConverterDefaultImpl` and `WingtipsToLightStepLifecycleListener` to add tags for the sanitized IDs to the original wingtips span for ID correlation instead of separate log messages.

This PR also reduces the verbosity of the default `JRETracer` in `WingtipsToLightStepLifecycleListener`, which significantly reduces log spam when there are communication issues with the span ingestor.