### PR TITLE
Bugfix/span serialization issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,11 @@ When `Tracer` completes a span it will log it to a SLF4J logger named `VALID_WIN
 <a name="mdc_info"></a> 
 #### Automatically attaching trace information to all log messages
 
-In addition to the logs this class outputs for completed spans it puts the trace ID and span JSON for the "current" span into the SLF4J [MDC](http://www.slf4j.org/manual.html#mdc) so that all your logs can be tagged with the current span's trace ID and/or full JSON. To utilize this you would need to add `%X{traceId}` and/or `%X{spanJson}` to your log pattern (*NOTE: this only works with SLF4J frameworks that support MDC, e.g. Logback and Log4j*). This causes *all* log messages, including ones that come from third party libraries and have no knowledge of distributed tracing, to be output with the current span's tracing information.
+In addition to the logs this class outputs for completed spans it puts the trace ID for the "current" span into the 
+SLF4J [MDC](http://www.slf4j.org/manual.html#mdc) so that all your logs can be tagged with the current span's trace ID. 
+To utilize this you would need to add `%X{traceId}` to your log pattern (*NOTE: this only works with SLF4J frameworks 
+that support MDC, e.g. Logback and Log4j*). This causes *all* log messages, including ones that come from third party 
+libraries and have no knowledge of distributed tracing, to be output with the current span's tracing information.
 
 Here is an example [Logback pattern](http://logback.qos.ch/manual/layouts.html) utilizing the tracing MDC info:
 
@@ -212,9 +216,16 @@ And here is what a log message output would look like when using this pattern:
 traceId=520819c556734c0c 14:43:53.483 INFO  [main] com.foo.Bar - important log message
 ```
 
-***This is one of the primary features and benefits of Wingtips - if you utilize this MDC feature then you'll be able to trivially collect all log messages related to a specific request across all services it touched even if some of those messages came from third party libraries.***
+***This is one of the primary features and benefits of Wingtips - if you utilize this MDC feature then you'll be able 
+to trivially collect all log messages related to a specific request across all services it touched even if some of 
+those messages came from third party libraries.***
 
-A [Log4j pattern](https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html) would look similar - in particular `%X{traceId}` to access the trace ID in the MDC is identical.
+A [Log4j pattern](https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html) would look 
+similar - in particular `%X{traceId}` to access the trace ID in the MDC is identical.
+
+Note: You can adjust which span fields are included in the MDC behavior by calling 
+`Tracer.setSpanFieldsForLoggerMdc(...)`. It's recommended that you always include trace ID, but if you want to also 
+include span ID, parent span ID, or even the full span JSON in the MDC (not recommended), you can.
 
 #### Changing output format
 

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ ext {
     jettyVersion = '9.3.21.v20170918'
 
     // JACOCO PROPERTIES
-    jacocoToolVersion = '0.8.2'
+    jacocoToolVersion = '0.8.4'
     // Anything in this jacocoExclusions list will be excluded from coverage reports.
     jacocoExclusions = []
     jacocoCoverageThresholdSetup = {

--- a/wingtips-core/src/main/java/com/nike/wingtips/Tracer.java
+++ b/wingtips-core/src/main/java/com/nike/wingtips/Tracer.java
@@ -7,16 +7,21 @@ import com.nike.wingtips.sampling.SampleAllTheThingsStrategy;
 import com.nike.wingtips.util.TracerManagedSpanStatus;
 import com.nike.wingtips.util.TracingState;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * <p>
@@ -101,11 +106,14 @@ import java.util.List;
  *     lost to network lag or any other bottlenecks between the services.
  * </p>
  * <p>
- *     In addition to the logs this class outputs for spans it puts the trace ID and span JSON for the "current" span into the SLF4J
- *     <a href="http://www.slf4j.org/manual.html#mdc">MDC</a> so that all your logs can be tagged with the current span's trace ID and/or full JSON. To utilize this you
- *     would need to add {@code %X{traceId}} and/or {@code %X{spanJson}} to your log pattern (NOTE: this only works with SLF4J frameworks that support MDC, e.g. logback
+ *     In addition to the logs this class outputs for spans it puts the trace ID for the "current" span into the SLF4J
+ *     <a href="http://www.slf4j.org/manual.html#mdc">MDC</a> so that all your logs can be tagged with the current span's trace ID. To utilize this you
+ *     would need to add {@code %X{traceId}} to your log pattern (NOTE: this only works with SLF4J frameworks that support MDC, e.g. logback
  *     and log4j). This causes *all* log messages, including ones that come from third party libraries and have no knowledge of distributed tracing, to be output with the
- *     current span's tracing information.
+ *     current span's tracing information. Note you can adjust which span fields are included in the MDC behavior by
+ *     calling {@link #setSpanFieldsForLoggerMdc(SpanFieldForLoggerMdc...)}. It's recommended that you always include
+ *     {@link SpanFieldForLoggerMdc#TRACE_ID}, but if you want to also include span ID, parent span ID, or even the
+ *     full span JSON in the MDC (not recommended), you can.
  * </p>
  * <p>
  *     NOTE: Due to the thread-local nature of this class it is more effort to integrate with reactive (asynchronous non-blocking) frameworks like Netty or actor frameworks
@@ -137,7 +145,6 @@ public class Tracer {
      * The options for how {@link Span} objects are represented when they are completed. To change how {@link Tracer} serializes spans when logging them
      * call {@link #setSpanLoggingRepresentation(SpanLoggingRepresentation)}.
      */
-    @SuppressWarnings("WeakerAccess")
     public enum SpanLoggingRepresentation {
         /**
          * Causes spans to be output in the logs using {@link Span#toJSON()}.
@@ -147,6 +154,61 @@ public class Tracer {
          * Causes spans to be output in the logs using {@link Span#toKeyValueString()}.
          */
         KEY_VALUE
+    }
+
+    /**
+     * The options for which {@link Span} fields are put into and taken out of the logger {@link MDC} as {@link Tracer}
+     * works with spans.
+     */
+    public enum SpanFieldForLoggerMdc {
+        /**
+         * MDC key for storing the current span's {@link Span#getTraceId()}.
+         */
+        TRACE_ID("traceId"),
+        /**
+         * MDC key for storing the current span's {@link Span#getSpanId()}.
+         */
+        SPAN_ID("spanId"),
+        /**
+         * MDC key for storing the current span's {@link Span#getParentSpanId()}.
+         */
+        PARENT_SPAN_ID("parentSpanId"),
+        /**
+         * MDC key for storing the current {@link Span} as a JSON string.
+         *
+         * <p>WARNING: This can get expensive in some use cases where processing hops threads frequently and the span
+         * state is changed often (i.e. lots of tags). Make sure you absolutely need this before including it in a call
+         * to {@link #setSpanFieldsForLoggerMdc(SpanFieldForLoggerMdc...)} or {@link #setSpanFieldsForLoggerMdc(Set)}.
+         */
+        FULL_SPAN_JSON("spanJson");
+
+        /**
+         * The key to use when calling {@link MDC#put(String, String)} or {@link MDC#remove(String)}.
+         */
+        public final String mdcKey;
+
+        SpanFieldForLoggerMdc(String mdcKey) {
+            this.mdcKey = mdcKey;
+        }
+
+        /**
+         * @param span The span to grab the value from.
+         * @return The string from the given span associated with this {@link SpanFieldForLoggerMdc}.
+         */
+        public @Nullable String getMdcValueForSpan(@NotNull Span span) {
+            switch (this) {
+                case TRACE_ID:
+                    return span.getTraceId();
+                case SPAN_ID:
+                    return span.getSpanId();
+                case PARENT_SPAN_ID:
+                    return span.getParentSpanId();
+                case FULL_SPAN_JSON:
+                    return span.toJSON();
+                default:
+                    throw new IllegalStateException("Unhandled SpanFieldForLoggerMdc type: " + this);
+            }
+        }
     }
 
     private static final String VALID_WINGTIPS_SPAN_LOGGER_NAME = "VALID_WINGTIPS_SPANS";
@@ -166,15 +228,6 @@ public class Tracer {
      */
     private static final Tracer INSTANCE = new Tracer();
 
-    /**
-     * MDC key for storing the current {@link Span} as a JSON string.
-     */
-    public static final String SPAN_JSON_MDC_KEY = "spanJson";
-    /**
-     * MDC key for storing the current span's {@link Span#getTraceId()}.
-     */
-    public static final String TRACE_ID_MDC_KEY = "traceId";
-
 
     /**
      * The sampling strategy this instance will use. Default to sampling everything. Never allow this field to be set to null.
@@ -190,6 +243,15 @@ public class Tracer {
      * The span representation that should be used when logging completed spans.
      */
     private SpanLoggingRepresentation spanLoggingRepresentation = SpanLoggingRepresentation.JSON;
+
+    /**
+     * The set of span fields that should be put into and taken out of the logger {@link MDC} as {@link Tracer} works
+     * with spans.
+     */
+    private SpanFieldForLoggerMdc[] spanFieldsForLoggerMdc =
+        new SpanFieldForLoggerMdc[]{ SpanFieldForLoggerMdc.TRACE_ID };
+    private Set<SpanFieldForLoggerMdc> cachedUnmodifiableSpanFieldsForLoggerMdc =
+        Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(spanFieldsForLoggerMdc)));
 
     private Tracer() { /* Intentionally private to enforce singleton pattern. */ }
 
@@ -621,6 +683,7 @@ public class Tracer {
         completeAndLogSpan(subSpan, false);
 
         // Now configure the MDC with the new current span.
+        //noinspection ConstantConditions
         configureMDC(currentSpanStack.peek());
     }
 
@@ -805,17 +868,20 @@ public class Tracer {
     /**
      * Sets the span variables on the MDC context.
      */
-    protected static void configureMDC(Span span) {
-        MDC.put(TRACE_ID_MDC_KEY, span.getTraceId());
-        MDC.put(SPAN_JSON_MDC_KEY, span.toJSON());
+    protected void configureMDC(@NotNull Span span) {
+        for (SpanFieldForLoggerMdc mdcField : this.spanFieldsForLoggerMdc) {
+            MDC.put(mdcField.mdcKey, mdcField.getMdcValueForSpan(span));
+        }
     }
+
 
     /**
      * Removes the MDC parameters.
      */
-    protected static void unconfigureMDC() {
-        MDC.remove(TRACE_ID_MDC_KEY);
-        MDC.remove(SPAN_JSON_MDC_KEY);
+    protected void unconfigureMDC() {
+        for (SpanFieldForLoggerMdc mdcField : this.spanFieldsForLoggerMdc) {
+            MDC.remove(mdcField.mdcKey);
+        }
     }
 
     /**
@@ -913,6 +979,62 @@ public class Tracer {
         this.spanLoggingRepresentation = spanLoggingRepresentation;
     }
 
+    /**
+     * @return The currently selected options for which span fields will be placed in the logger {@link MDC} as
+     * {@link Tracer} works with spans, wrapped in a {@link Collections#unmodifiableSet(Set)} to prevent direct
+     * modification. This will never return null.
+     */
+    public Set<SpanFieldForLoggerMdc> getSpanFieldsForLoggerMdc() {
+        return cachedUnmodifiableSpanFieldsForLoggerMdc;
+    }
+
+    /**
+     * Tells {@link Tracer} which {@link Span} fields should be included in the logger {@link MDC} when the current
+     * span for a thread changes. The default behavior without calling this method just includes
+     * {@link SpanFieldForLoggerMdc#TRACE_ID}.
+     *
+     * <p>NOTE: It's recommended that you always include {@link SpanFieldForLoggerMdc#TRACE_ID}.
+     *
+     * @param fieldsForMdc The fields you want included in the logger {@link MDC}. You can pass null or an empty array,
+     * in which case the MDC will never be updated with span info. NOTE: It's recommended that you always include
+     * {@link SpanFieldForLoggerMdc#TRACE_ID}.
+     */
+    public void setSpanFieldsForLoggerMdc(SpanFieldForLoggerMdc ... fieldsForMdc) {
+        if (fieldsForMdc == null) {
+            fieldsForMdc = new SpanFieldForLoggerMdc[0];
+        }
+        
+        setSpanFieldsForLoggerMdc(new LinkedHashSet<>(Arrays.asList(fieldsForMdc)));
+    }
+
+    /**
+     * Tells {@link Tracer} which {@link Span} fields should be included in the logger {@link MDC} when the current
+     * span for a thread changes. The default behavior without calling this method just includes
+     * {@link SpanFieldForLoggerMdc#TRACE_ID}.
+     *
+     * <p>NOTE: It's recommended that you always include {@link SpanFieldForLoggerMdc#TRACE_ID}.
+     *
+     * @param fieldsForMdc The fields you want included in the logger {@link MDC}. You can pass null or an empty set,
+     * in which case the MDC will never be updated with span info. NOTE: It's recommended that you always include
+     * {@link SpanFieldForLoggerMdc#TRACE_ID}.
+     */
+    public void setSpanFieldsForLoggerMdc(Set<SpanFieldForLoggerMdc> fieldsForMdc) {
+        if (fieldsForMdc == null) {
+            fieldsForMdc = Collections.emptySet();
+        }
+
+        this.spanFieldsForLoggerMdc = fieldsForMdc.toArray(new SpanFieldForLoggerMdc[0]);
+        this.cachedUnmodifiableSpanFieldsForLoggerMdc =
+            Collections.unmodifiableSet(new LinkedHashSet<>(fieldsForMdc));
+
+        if (!fieldsForMdc.contains(SpanFieldForLoggerMdc.TRACE_ID)) {
+            classLogger.warn(
+                "setSpanFieldsForLoggerMdc(...) was called without including TRACE_ID. This is not recommended! "
+                + "It's recommended that you always include TRACE_ID unless you really know what you're doing. "
+                + "span_fields_for_mdc_received={}", fieldsForMdc
+            );
+        }
+    }
 
     /**
      * Notifies all listeners that the given span was started using {@link SpanLifecycleListener#spanStarted(Span)}

--- a/wingtips-core/src/main/java/com/nike/wingtips/http/HttpRequestTracingUtils.java
+++ b/wingtips-core/src/main/java/com/nike/wingtips/http/HttpRequestTracingUtils.java
@@ -140,7 +140,7 @@ public class HttpRequestTracingUtils {
     protected static String getTraceId(RequestWithHeaders request) {
         String requestTraceId = getHeaderWithAttributeAsBackup(request, TraceHeaders.TRACE_ID);
 
-        logger.debug(String.format("TraceId from client is TraceId=%s", requestTraceId));
+        logger.debug("TraceId from client is TraceId={}", requestTraceId);
 
         return requestTraceId;
     }

--- a/wingtips-core/src/main/java/com/nike/wingtips/tags/HttpTagAndSpanNamingStrategy.java
+++ b/wingtips-core/src/main/java/com/nike/wingtips/tags/HttpTagAndSpanNamingStrategy.java
@@ -155,7 +155,7 @@ public abstract class HttpTagAndSpanNamingStrategy<REQ, RES> {
      * Callers must always check for a null return value, and generate a backup span name in those cases.</b>
      *
      * <p>This method is final and delegates to {@link #doGetInitialSpanName(Object, HttpTagAndSpanNamingAdapter)}.
-     * That delegate method call is surrounded with a try/catch so that it this method will never throw an exception.
+     * That delegate method call is surrounded with a try/catch so that this method will never throw an exception.
      * If an exception occurs then the error will be logged and null will be returned. Since this method is final, if
      * you want to override the behavior of this method then you should override {@link
      * #doGetInitialSpanName(Object, HttpTagAndSpanNamingAdapter)}.
@@ -198,7 +198,7 @@ public abstract class HttpTagAndSpanNamingStrategy<REQ, RES> {
      *
      * <p>This method is final and delegates to {@link
      * #doHandleRequestTagging(Span, Object, HttpTagAndSpanNamingAdapter)}. That delegate method call is surrounded
-     * with a try/catch so that it this method will never throw an exception. If an exception occurs then the error
+     * with a try/catch so that this method will never throw an exception. If an exception occurs then the error
      * will be logged but will not propagate outside this method. Since this method is final, if you want to override
      * the behavior of this method then you should override {@link
      * #doHandleRequestTagging(Span, Object, HttpTagAndSpanNamingAdapter)}.
@@ -252,7 +252,7 @@ public abstract class HttpTagAndSpanNamingStrategy<REQ, RES> {
      *     <li>{@link #doExtraWingtipsTagging(Span, Object, Object, Throwable, HttpTagAndSpanNamingAdapter)}</li>
      * </ul>
      *
-     * Those delegate method calls are surrounded with try/catch blocks so that it this method will never throw an
+     * Those delegate method calls are surrounded with try/catch blocks so that this method will never throw an
      * exception, and an exception in one won't prevent the others from executing. If an exception occurs then the
      * error will be logged but will not propagate outside this method. Since this method is final, if you want to
      * override the behavior of this method then you should override the relevant delegate method(s).

--- a/wingtips-core/src/test/java/com/nike/wingtips/TracerTest.java
+++ b/wingtips-core/src/test/java/com/nike/wingtips/TracerTest.java
@@ -1,11 +1,13 @@
 package com.nike.wingtips;
 
 import com.nike.wingtips.Span.SpanPurpose;
+import com.nike.wingtips.Tracer.SpanFieldForLoggerMdc;
 import com.nike.wingtips.lifecyclelistener.SpanLifecycleListener;
 import com.nike.wingtips.sampling.RootSpanSamplingStrategy;
 import com.nike.wingtips.sampling.SampleAllTheThingsStrategy;
 import com.nike.wingtips.util.TracerManagedSpanStatus;
 import com.nike.wingtips.util.TracingState;
+import com.nike.wingtips.util.parser.SpanParser;
 
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
@@ -23,17 +25,22 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 
+import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Fail.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -51,6 +58,7 @@ public class TracerTest {
         Tracer.getInstance().setRootSpanSamplingStrategy(new SampleAllTheThingsStrategy());
         Tracer.getInstance().removeAllSpanLifecycleListeners();
         Tracer.getInstance().setSpanLoggingRepresentation(Tracer.SpanLoggingRepresentation.JSON);
+        Tracer.getInstance().setSpanFieldsForLoggerMdc(singleton(SpanFieldForLoggerMdc.TRACE_ID));
     }
 
     @Before
@@ -91,8 +99,7 @@ public class TracerTest {
     public void startRequestWithRootSpan_should_start_valid_root_span_without_parent() {
         // given: no span started
         assertThat(Tracer.getInstance().getCurrentSpan()).isNull();
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
         assertThat(getSpanStackSize()).isEqualTo(0);
 
         // when: Tracer.startRequestWithRootSpan(String) is called to start a span without a parent
@@ -117,16 +124,14 @@ public class TracerTest {
         assertThat(span.isSampleable()).isTrue();
         assertThat(span.getUserId()).isNull();
         assertThat(span.getSpanPurpose()).isEqualTo(SpanPurpose.SERVER);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(span.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(span.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(span.getTraceId());
     }
 
     @Test
     public void startRequestWithRootSpan_should_start_valid_root_span_without_parent_with_userid() {
         // given: no span started
         assertThat(Tracer.getInstance().getCurrentSpan()).isNull();
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
         assertThat(getSpanStackSize()).isEqualTo(0);
 
         // when: Tracer.startRequestWithRootSpan(String) is called to start a span without a parent
@@ -151,8 +156,7 @@ public class TracerTest {
         assertThat(span.isSampleable()).isTrue();
         assertThat(span.getUserId()).isEqualTo("testUserId");
         assertThat(span.getSpanPurpose()).isEqualTo(SpanPurpose.SERVER);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(span.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(span.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(span.getTraceId());
     }
 
     @Test
@@ -177,8 +181,7 @@ public class TracerTest {
         // given: no span started and a parent span exists
         Span parentSpan = Span.generateRootSpanForNewTrace("parentspan", SpanPurpose.LOCAL_ONLY).build();
         assertThat(Tracer.getInstance().getCurrentSpan()).isNull();
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
         assertThat(getSpanStackSize()).isEqualTo(0);
 
         // when: Tracer.startRequestWithChildSpan(Span, String) is called to start a span with a parent
@@ -204,8 +207,7 @@ public class TracerTest {
         assertThat(span.isSampleable()).isEqualTo(parentSpan.isSampleable());
         assertThat(span.getUserId()).isNull();
         assertThat(span.getSpanPurpose()).isEqualTo(SpanPurpose.SERVER);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(span.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(span.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(span.getTraceId());
     }
 
     @Test
@@ -215,8 +217,7 @@ public class TracerTest {
                               .withUserId("testUserId")
                               .build();
         assertThat(Tracer.getInstance().getCurrentSpan()).isNull();
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
         assertThat(getSpanStackSize()).isEqualTo(0);
 
         // when: Tracer.startRequestWithChildSpan(Span, String) is called to start a span with a parent
@@ -242,8 +243,7 @@ public class TracerTest {
         assertThat(span.isSampleable()).isEqualTo(parentSpan.isSampleable());
         assertThat(span.getUserId()).isEqualTo("testUserId");
         assertThat(span.getSpanPurpose()).isEqualTo(SpanPurpose.SERVER);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(span.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(span.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(span.getTraceId());
     }
 
     @Test
@@ -287,8 +287,7 @@ public class TracerTest {
         boolean sampleable = false;
         String userId = UUID.randomUUID().toString();
         assertThat(Tracer.getInstance().getCurrentSpan()).isNull();
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
 
         // when
         long beforeNanoTime = System.nanoTime();
@@ -300,8 +299,7 @@ public class TracerTest {
 
         // then
         assertThat(Tracer.getInstance().getCurrentSpan()).isEqualTo(span);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(span.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(span.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(span.getTraceId());
         assertThat(span.getTraceId()).isEqualTo(traceId);
         assertThat(span.getParentSpanId()).isEqualTo(parentSpanId);
         assertThat(span.getSpanId()).isNotEmpty();
@@ -355,8 +353,7 @@ public class TracerTest {
         assertThat(subspan.getSpanId()).isNotNull();
         assertThat(subspan.isSampleable()).isEqualTo(firstSpan.isSampleable());
         assertThat(subspan.getSpanPurpose()).isEqualTo(spanPurpose);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(subspan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(subspan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(subspan.getTraceId());
     }
 
     @DataProvider(value = {
@@ -369,7 +366,7 @@ public class TracerTest {
     public void startSubSpan_should_function_like_startRequestWithRootSpan_when_there_is_no_parent_span(SpanPurpose spanPurpose) {
         // given: no span started
         assertThat(Tracer.getInstance().getCurrentSpan()).isNull();
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
         assertThat(getSpanStackSize()).isEqualTo(0);
 
         // when: Tracer.startSubSpan(String) is called to start a subspan
@@ -393,8 +390,7 @@ public class TracerTest {
         assertThat(subspan.getSpanId()).isNotNull();
         assertThat(subspan.isSampleable()).isTrue();
         assertThat(subspan.getSpanPurpose()).isEqualTo(spanPurpose);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(subspan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(subspan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(subspan.getTraceId());
     }
 
     @DataProvider(value = {
@@ -522,7 +518,7 @@ public class TracerTest {
         return new Object[][] {
                 { null },
                 { new LinkedList<>() },
-                { new LinkedList<>(Collections.singleton(rootSpan)) },
+                { new LinkedList<>(singleton(rootSpan)) },
                 { new LinkedList<>(Arrays.asList(rootSpan, childSpan)) }
         };
     }
@@ -546,33 +542,128 @@ public class TracerTest {
     }
 
     @Test
-    public void configureMDC_should_set_span_values_on_MDC() throws Exception {
+    public void getMdcValueForSpan_works_as_expected() {
+        for (SpanFieldForLoggerMdc fieldForMdc : SpanFieldForLoggerMdc.values()) {
+            // given
+            Span span = Span.newBuilder("foo", SpanPurpose.SERVER)
+                            .withParentSpanId(TraceAndSpanIdGenerator.generateId())
+                            .withTag("fooTag", "fooTagValue")
+                            .withTimestampedAnnotation(Span.TimestampedAnnotation.forCurrentTime("fooEvent"))
+                            .build();
+
+            String expectedResult;
+            switch (fieldForMdc) {
+                case TRACE_ID:
+                    expectedResult = span.getTraceId();
+                    break;
+                case SPAN_ID:
+                    expectedResult = span.getSpanId();
+                    break;
+                case PARENT_SPAN_ID:
+                    expectedResult = span.getParentSpanId();
+                    break;
+                case FULL_SPAN_JSON:
+                    expectedResult = SpanParser.convertSpanToJSON(span);
+                    break;
+                default:
+                    throw new RuntimeException("Test doesn't cover SpanFieldForLoggerMdc enum: " + fieldForMdc);
+            }
+
+            // when
+            String result = fieldForMdc.getMdcValueForSpan(span);
+
+            // then
+            assertThat(result).isEqualTo(expectedResult);
+        }
+    }
+
+    @DataProvider(value = {
+        "null",
+        "",
+        "TRACE_ID",
+        "TRACE_ID,SPAN_ID,PARENT_SPAN_ID,FULL_SPAN_JSON"
+    }, splitBy = "\\|")
+    @Test
+    public void configureMDC_should_set_span_values_on_MDC_based_on_spanFieldsForLoggerMdc(
+        String rawSpanFields
+    ) {
         // given
-        Span span = Span.newBuilder("test-span", SpanPurpose.LOCAL_ONLY).withParentSpanId("3").build();
-        String expected = span.toJSON();
+        Span span = Span.newBuilder("test-span", SpanPurpose.LOCAL_ONLY)
+                        .withParentSpanId("3")
+                        .withTag("fooTag", "fooTagValue")
+                        .withTimestampedAnnotation(Span.TimestampedAnnotation.forCurrentTime("fooEvent"))
+                        .build();
+
+        Set<SpanFieldForLoggerMdc> spanFieldsForMdc = parseRawSpanFieldsForMdc(rawSpanFields);
+        Tracer.getInstance().setSpanFieldsForLoggerMdc(spanFieldsForMdc);
 
         // when
-        Tracer.configureMDC(span);
+        Tracer.getInstance().configureMDC(span);
 
         // then
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(expected);
+        for (SpanFieldForLoggerMdc fieldForMdc : SpanFieldForLoggerMdc.values()) {
+            String actualMdcValue = MDC.get(fieldForMdc.mdcKey);
+            if (spanFieldsForMdc != null && spanFieldsForMdc.contains(fieldForMdc)) {
+                assertThat(actualMdcValue).isEqualTo(fieldForMdc.getMdcValueForSpan(span));
+            }
+            else {
+                assertThat(actualMdcValue).isNull();
+            }
+        }
+    }
+
+    private Set<SpanFieldForLoggerMdc> parseRawSpanFieldsForMdc(String rawSpanFields) {
+        if (rawSpanFields == null) {
+            return null;
+        }
+
+        if (rawSpanFields.trim().isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        return Arrays.stream(rawSpanFields.split(","))
+                     .map(SpanFieldForLoggerMdc::valueOf)
+                     .collect(Collectors.toSet());
+    }
+
+    @DataProvider(value = {
+        "null",
+        "",
+        "TRACE_ID",
+        "TRACE_ID,SPAN_ID,PARENT_SPAN_ID,FULL_SPAN_JSON"
+    }, splitBy = "\\|")
+    @Test
+    public void unconfigureMDC_should_unset_span_values_on_MDC_based_on_spanFieldsForLoggerMdc(
+        String rawSpanFields
+    ) {
+        // given
+        Span span = Span.newBuilder("test-span", SpanPurpose.LOCAL_ONLY)
+                        .withParentSpanId("3")
+                        .withTag("fooTag", "fooTagValue")
+                        .withTimestampedAnnotation(Span.TimestampedAnnotation.forCurrentTime("fooEvent"))
+                        .build();
+
+        Set<SpanFieldForLoggerMdc> spanFieldsForMdc = parseRawSpanFieldsForMdc(rawSpanFields);
+        Tracer.getInstance().setSpanFieldsForLoggerMdc(spanFieldsForMdc);
+
+        Tracer.getInstance().configureMDC(span);
+
+        String miscUnrelatedMdcPropKey = "miscUnrelatedMdcProp";
+        String miscUnrelatedMdcPropValue = UUID.randomUUID().toString();
+        MDC.put(miscUnrelatedMdcPropKey, miscUnrelatedMdcPropValue);
+
+        // when
+        Tracer.getInstance().unconfigureMDC();
+
+        // then
+        for (SpanFieldForLoggerMdc fieldForMdc : SpanFieldForLoggerMdc.values()) {
+            assertThat(MDC.get(fieldForMdc.mdcKey)).isNull();
+        }
+        assertThat(MDC.get(miscUnrelatedMdcPropKey)).isEqualTo(miscUnrelatedMdcPropValue);
     }
 
     @Test
-    public void unconfigureMDC_should_unset_span_values_on_MDC() throws Exception {
-        // given
-        Span span = Span.newBuilder("test-span", SpanPurpose.LOCAL_ONLY).withParentSpanId("3").build();
-        Tracer.configureMDC(span);
-
-        // when
-        Tracer.unconfigureMDC();
-
-        // then
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
-    }
-
-    @Test
-    public void getCurrentSpan_should_return_current_span() throws Exception {
+    public void getCurrentSpan_should_return_current_span() {
         // given
         Tracer tracer = Tracer.getInstance();
         tracer.startRequestWithRootSpan("test-span");
@@ -612,8 +703,7 @@ public class TracerTest {
         verifyDurationBetweenLowerAndUpperBounds(span, beforeNanoTime, afterNanoTime);
         assertThat(Tracer.getInstance().getCurrentSpan()).isNull();
         assertThat(getSpanStackSize()).isEqualTo(0);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
     }
 
     @Test
@@ -647,16 +737,14 @@ public class TracerTest {
         verifyDurationBetweenLowerAndUpperBounds(subspan2, beforeNanoTime, afterNanoTime);
         assertThat(Tracer.getInstance().getCurrentSpan()).isNull();
         assertThat(getSpanStackSize()).isEqualTo(0);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
     }
 
     @Test
     public void completeRequestSpan_should_do_nothing_if_there_is_no_span_to_complete() {
         // given: no span started
         assertThat(Tracer.getInstance().getCurrentSpan()).isNull();
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
         assertThat(getSpanStackSize()).isEqualTo(0);
 
         // when: completeRequestSpan() is called
@@ -664,8 +752,7 @@ public class TracerTest {
 
         // then: nothing should be done
         assertThat(Tracer.getInstance().getCurrentSpan()).isNull();
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
         assertThat(getSpanStackSize()).isEqualTo(0);
     }
 
@@ -694,8 +781,7 @@ public class TracerTest {
         assertThat(Tracer.getInstance().getCurrentSpan()).isNotNull();
         assertThat(Tracer.getInstance().getCurrentSpan()).isSameAs(parentSpan);
         assertThat(getSpanStackSize()).isEqualTo(1);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(parentSpan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(parentSpan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(parentSpan.getTraceId());
     }
 
     @Test
@@ -734,7 +820,7 @@ public class TracerTest {
     }
 
     @Test
-    public void starting_request_span_should_configure_MDC_and_completing_it_should_unset_MDC() throws Exception {
+    public void starting_request_span_should_configure_MDC_and_completing_it_should_unset_MDC() {
         // given
         Tracer tracer = Tracer.getInstance();
 
@@ -742,24 +828,19 @@ public class TracerTest {
         tracer.startRequestWithRootSpan("test-span");
 
         // then
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNotNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNotNull();
 
         // and when
         tracer.completeRequestSpan();
 
         // then
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
     }
 
     @Test
     public void setRootSpanSamplingStrategy_should_set_the_strategy() {
         // given: known unique sampling strategy
-        RootSpanSamplingStrategy strategy = new RootSpanSamplingStrategy() {
-            @Override
-            public boolean isNextRootSpanSampleable() {
-                return false;
-            }
-        };
+        RootSpanSamplingStrategy strategy = () -> false;
 
         // when: setRootSpanSamplingStrategy() is called
         Tracer.getInstance().setRootSpanSamplingStrategy(strategy);
@@ -1147,16 +1228,14 @@ public class TracerTest {
         Tracer tracer = Tracer.getInstance();
         Span parentSpan = tracer.startRequestWithRootSpan("foo");
         Span subspan = tracer.startSubSpan("bar", SpanPurpose.LOCAL_ONLY);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(subspan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(subspan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(subspan.getTraceId());
         assertThat(getSpanStackSize()).isEqualTo(2);
 
         // when
         Deque<Span> unregisteredStack = tracer.unregisterFromThread();
 
         // then
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
         assertThat(getSpanStackSize()).isEqualTo(0);
 
         assertThat(unregisteredStack).hasSize(2);
@@ -1175,16 +1254,14 @@ public class TracerTest {
         newSpanStack.push(parentSpan);
         newSpanStack.push(subspan);
 
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
 
         // when
         tracer.registerWithThread(newSpanStack);
 
         // then
         // our stack was registered, so subspan should be current
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(subspan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(subspan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(subspan.getTraceId());
         assertThat(tracer.getCurrentSpan()).isEqualTo(subspan);
 
         // a *copy* of the stack we passed in should have been registered, and modifying the original stack should not affect Tracer's stack
@@ -1200,7 +1277,7 @@ public class TracerTest {
     @Test
     public void registerWithThread_should_work_as_advertised_if_existing_stack_is_empty() {
         // given
-        getSpanStackThreadLocal().set(new LinkedList<Span>());
+        getSpanStackThreadLocal().set(new LinkedList<>());
         Tracer tracer = Tracer.getInstance();
 
         Deque<Span> newSpanStack = new LinkedList<>();
@@ -1209,16 +1286,14 @@ public class TracerTest {
         newSpanStack.push(parentSpan);
         newSpanStack.push(subspan);
 
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
 
         // when
         tracer.registerWithThread(newSpanStack);
 
         // then
         // our stack was registered, so subspan should be current
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(subspan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(subspan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(subspan.getTraceId());
         assertThat(tracer.getCurrentSpan()).isEqualTo(subspan);
 
         // a *copy* of the stack we passed in should have been registered, and modifying the original stack should not affect Tracer's stack
@@ -1243,15 +1318,13 @@ public class TracerTest {
         newSpanStack.push(parentSpan);
         newSpanStack.push(subspan);
 
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(existingSpan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(existingSpan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(existingSpan.getTraceId());
 
         // when
         tracer.registerWithThread(newSpanStack);
 
         // then
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(subspan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(subspan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(subspan.getTraceId());
 
         Deque<Span> spanStack = getSpanStackThreadLocal().get();
         assertThat(spanStack).isEqualTo(newSpanStack);
@@ -1263,8 +1336,7 @@ public class TracerTest {
         Tracer tracer = Tracer.getInstance();
         tracer.startRequestWithRootSpan("foo");
         Span subspan = tracer.startSubSpan("bar", SpanPurpose.LOCAL_ONLY);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(subspan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(subspan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(subspan.getTraceId());
 
         // when
         Deque<Span> spanStack = getSpanStackThreadLocal().get();
@@ -1272,8 +1344,7 @@ public class TracerTest {
 
         // then
         assertThat(getSpanStackThreadLocal().get()).isEqualTo(spanStack);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(subspan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(subspan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(subspan.getTraceId());
     }
 
     @Test
@@ -1282,8 +1353,7 @@ public class TracerTest {
         Tracer tracer = Tracer.getInstance();
         tracer.startRequestWithRootSpan("foo");
         Span subspan = tracer.startSubSpan("bar", SpanPurpose.LOCAL_ONLY);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(subspan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(subspan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(subspan.getTraceId());
 
         // when
         Deque<Span> spanStack = getSpanStackThreadLocal().get();
@@ -1291,8 +1361,7 @@ public class TracerTest {
 
         // then
         assertThat(getSpanStackThreadLocal().get()).isEqualTo(spanStack);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(subspan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(subspan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(subspan.getTraceId());
     }
 
     @Test
@@ -1301,16 +1370,14 @@ public class TracerTest {
         Tracer tracer = Tracer.getInstance();
         tracer.startRequestWithRootSpan("foo");
         Span subspan = tracer.startSubSpan("bar", SpanPurpose.LOCAL_ONLY);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(subspan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(subspan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(subspan.getTraceId());
 
         // when
         tracer.registerWithThread(null);
 
         // then
         assertThat(getSpanStackThreadLocal().get()).isNull();
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
     }
 
     @Test
@@ -1319,8 +1386,7 @@ public class TracerTest {
         Tracer tracer = Tracer.getInstance();
         tracer.startRequestWithRootSpan("foo");
         Span subspan = tracer.startSubSpan("bar", SpanPurpose.LOCAL_ONLY);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(subspan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(subspan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(subspan.getTraceId());
 
         // when
         Deque<Span> emptyStack = new LinkedList<>();
@@ -1328,8 +1394,7 @@ public class TracerTest {
 
         // then
         assertThat(getSpanStackThreadLocal().get()).isEqualTo(emptyStack);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
     }
 
     @DataProvider
@@ -1376,66 +1441,56 @@ public class TracerTest {
         // Start some spans for request A
         Span reqAParentSpan = tracer.startRequestWithRootSpan("req_A_foo");
         Span reqASubSpan = tracer.startSubSpan("req_A_bar", SpanPurpose.LOCAL_ONLY);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(reqASubSpan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(reqASubSpan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(reqASubSpan.getTraceId());
         assertThat(tracer.getCurrentSpan()).isEqualTo(reqASubSpan);
 
         // Unregister in preparation for request B
         Deque<Span> reqAStack = tracer.unregisterFromThread();
 
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
         assertThat(tracer.getCurrentSpan()).isNull();
 
         // Start some spans for request B
         Span reqBParentSpan = tracer.startRequestWithRootSpan("req_B_foo");
         Span reqBSubSpan = tracer.startSubSpan("req_B_bar", SpanPurpose.LOCAL_ONLY);
 
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(reqBSubSpan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(reqBSubSpan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(reqBSubSpan.getTraceId());
         assertThat(tracer.getCurrentSpan()).isEqualTo(reqBSubSpan);
 
         // Unregister in preparation for going back to request A
         Deque<Span> reqBStack = tracer.unregisterFromThread();
 
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
         assertThat(tracer.getCurrentSpan()).isNull();
 
         // Re-register request A's stack
         tracer.registerWithThread(reqAStack);
 
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(reqASubSpan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(reqASubSpan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(reqASubSpan.getTraceId());
         assertThat(tracer.getCurrentSpan()).isEqualTo(reqASubSpan);
 
         // Complete request A
         tracer.completeSubSpan();
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(reqAParentSpan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(reqAParentSpan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(reqAParentSpan.getTraceId());
         assertThat(tracer.getCurrentSpan()).isEqualTo(reqAParentSpan);
 
         tracer.completeRequestSpan();
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
         assertThat(tracer.getCurrentSpan()).isNull();
 
         // Re-register request B's stack
         tracer.registerWithThread(reqBStack);
 
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(reqBSubSpan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(reqBSubSpan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(reqBSubSpan.getTraceId());
         assertThat(tracer.getCurrentSpan()).isEqualTo(reqBSubSpan);
 
         // Complete request B
         tracer.completeSubSpan();
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(reqBParentSpan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(reqBParentSpan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(reqBParentSpan.getTraceId());
         assertThat(tracer.getCurrentSpan()).isEqualTo(reqBParentSpan);
 
         tracer.completeRequestSpan();
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isNull();
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isNull();
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isNull();
         assertThat(tracer.getCurrentSpan()).isNull();
     }
 
@@ -1456,8 +1511,7 @@ public class TracerTest {
         Span parentSpan = tracer.startRequestWithRootSpan("foo");
         Span subspan = tracer.startSubSpan("bar", SpanPurpose.LOCAL_ONLY);
 
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(subspan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(subspan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(subspan.getTraceId());
 
         // when
         Deque<Span> stack = tracer.getCurrentSpanStackCopy();
@@ -1469,17 +1523,15 @@ public class TracerTest {
 
         // Clear the returned stack
         stack.clear();
-        assertThat(stack.isEmpty()).isTrue();
+        assertThat(stack).isEmpty();
 
         // then
         // Now verify that tracer still points to a stack that contains both spans. This proves that getCurrentSpanStackCopy() returned a copy, not the original
         assertThat(tracer.getCurrentSpan()).isEqualTo(subspan);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(subspan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(subspan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(subspan.getTraceId());
         tracer.completeSubSpan();
         assertThat(tracer.getCurrentSpan()).isEqualTo(parentSpan);
-        assertThat(MDC.get(Tracer.TRACE_ID_MDC_KEY)).isEqualTo(parentSpan.getTraceId());
-        assertThat(MDC.get(Tracer.SPAN_JSON_MDC_KEY)).isEqualTo(parentSpan.toJSON());
+        assertThat(MDC.get(SpanFieldForLoggerMdc.TRACE_ID.mdcKey)).isEqualTo(parentSpan.getTraceId());
     }
 
     @Test
@@ -1497,7 +1549,7 @@ public class TracerTest {
 
         {
             // and when - empty stack
-            tracer.registerWithThread(new LinkedList<Span>());
+            tracer.registerWithThread(new LinkedList<>());
 
             // then
             assertThat(tracer.getCurrentSpanStackSize()).isEqualTo(0);
@@ -1776,6 +1828,7 @@ public class TracerTest {
         // given
         Span nonCurrentRootSpan = Tracer.getInstance().startRequestWithRootSpan("root");
         Span nonCurrentSubspan = Tracer.getInstance().startSubSpan("subspan1", SpanPurpose.LOCAL_ONLY);
+        @SuppressWarnings("unused")
         Span currentSubspan = Tracer.getInstance().startSubSpan("subspan2", SpanPurpose.LOCAL_ONLY);
 
         // expect
@@ -1799,6 +1852,97 @@ public class TracerTest {
         // then
         assertThat(tmssManual).isEqualTo(TracerManagedSpanStatus.UNMANAGED_SPAN);
         assertThat(tmssCompleted).isEqualTo(TracerManagedSpanStatus.UNMANAGED_SPAN);
+    }
+
+    @Test
+    public void setSpanFieldsForLoggerMdc_varargs_sets_fields_as_expected() {
+        // given
+        SpanFieldForLoggerMdc[] selectedFields = new SpanFieldForLoggerMdc[] {
+            SpanFieldForLoggerMdc.TRACE_ID,
+            SpanFieldForLoggerMdc.SPAN_ID
+        };
+
+        assertThat(Tracer.getInstance().getSpanFieldsForLoggerMdc())
+            .isEqualTo(singleton(SpanFieldForLoggerMdc.TRACE_ID));
+
+        // when
+        Tracer.getInstance().setSpanFieldsForLoggerMdc(selectedFields);
+
+        // then
+        assertThat(Tracer.getInstance().getSpanFieldsForLoggerMdc())
+            .isEqualTo(new HashSet<>(Arrays.asList(selectedFields)));
+    }
+
+    @DataProvider(value = {
+        "true",
+        "false"
+    })
+    @Test
+    public void setSpanFieldsForLoggerMdc_varargs_handles_empty_or_null_array_gracefully(boolean isNullArray) {
+        // given
+        SpanFieldForLoggerMdc[] selectedFields = (isNullArray) ? null : new SpanFieldForLoggerMdc[0];
+
+        assertThat(Tracer.getInstance().getSpanFieldsForLoggerMdc())
+            .isEqualTo(singleton(SpanFieldForLoggerMdc.TRACE_ID));
+        
+        // when
+        Tracer.getInstance().setSpanFieldsForLoggerMdc(selectedFields);
+
+        // then
+        assertThat(Tracer.getInstance().getSpanFieldsForLoggerMdc()).isEmpty();
+    }
+
+    @Test
+    public void setSpanFieldsForLoggerMdc_with_Set_arg_sets_fields_as_expected() {
+        // given
+        Set<SpanFieldForLoggerMdc> selectedFields = new HashSet<>(Arrays.asList(
+            SpanFieldForLoggerMdc.TRACE_ID,
+            SpanFieldForLoggerMdc.SPAN_ID
+        ));
+
+        assertThat(Tracer.getInstance().getSpanFieldsForLoggerMdc())
+            .isEqualTo(singleton(SpanFieldForLoggerMdc.TRACE_ID));
+
+        // when
+        Tracer.getInstance().setSpanFieldsForLoggerMdc(selectedFields);
+
+        // then
+        assertThat(Tracer.getInstance().getSpanFieldsForLoggerMdc()).isEqualTo(selectedFields);
+    }
+
+    @DataProvider(value = {
+        "true",
+        "false"
+    })
+    @Test
+    public void setSpanFieldsForLoggerMdc_with_Set_arg_handles_empty_or_null_array_gracefully(boolean isNullSet) {
+        // given
+        Set<SpanFieldForLoggerMdc> selectedFields = (isNullSet) ? null : new HashSet<>();
+
+        assertThat(Tracer.getInstance().getSpanFieldsForLoggerMdc())
+            .isEqualTo(singleton(SpanFieldForLoggerMdc.TRACE_ID));
+
+        // when
+        Tracer.getInstance().setSpanFieldsForLoggerMdc(selectedFields);
+
+        // then
+        assertThat(Tracer.getInstance().getSpanFieldsForLoggerMdc()).isEmpty();
+    }
+
+    @Test
+    public void getSpanFieldsForLoggerMdc_returns_unmodifiable_Set() {
+        // given
+        Set<SpanFieldForLoggerMdc> spanFieldsForMdcGetterResult = Tracer.getInstance().getSpanFieldsForLoggerMdc();
+
+        // when
+        Throwable ex1 = catchThrowable(() -> spanFieldsForMdcGetterResult.add(SpanFieldForLoggerMdc.TRACE_ID));
+        Throwable ex2 = catchThrowable(() -> spanFieldsForMdcGetterResult.remove(SpanFieldForLoggerMdc.TRACE_ID));
+        Throwable ex3 = catchThrowable(spanFieldsForMdcGetterResult::clear);
+
+        // then
+        assertThat(ex1).isInstanceOf(UnsupportedOperationException.class);
+        assertThat(ex2).isInstanceOf(UnsupportedOperationException.class);
+        assertThat(ex3).isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test

--- a/wingtips-core/src/test/java/com/nike/wingtips/util/AsyncWingtipsHelperJava7Test.java
+++ b/wingtips-core/src/test/java/com/nike/wingtips/util/AsyncWingtipsHelperJava7Test.java
@@ -3,6 +3,7 @@ package com.nike.wingtips.util;
 import com.nike.internal.util.Pair;
 import com.nike.wingtips.Span;
 import com.nike.wingtips.Tracer;
+import com.nike.wingtips.Tracer.SpanFieldForLoggerMdc;
 import com.nike.wingtips.util.asynchelperwrapper.CallableWithTracing;
 import com.nike.wingtips.util.asynchelperwrapper.ExecutorServiceWithTracing;
 import com.nike.wingtips.util.asynchelperwrapper.RunnableWithTracing;
@@ -305,8 +306,7 @@ public class AsyncWingtipsHelperJava7Test {
                 // MDC will have been populated with tracing info.
                 expectedMdcInfo = new HashMap<>();
                 Span expectedSpan = spanStackForLinking.peek();
-                expectedMdcInfo.put(Tracer.TRACE_ID_MDC_KEY, expectedSpan.getTraceId());
-                expectedMdcInfo.put(Tracer.SPAN_JSON_MDC_KEY, expectedSpan.toJSON());
+                expectedMdcInfo.put(SpanFieldForLoggerMdc.TRACE_ID.mdcKey, expectedSpan.getTraceId());
             }
         }
         else {
@@ -314,8 +314,7 @@ public class AsyncWingtipsHelperJava7Test {
             expectedMdcInfo = new HashMap<>(mdcInfoForLinking);
             if (useNullSpanStack) {
                 // In the case of a null span stack, the trace info would be removed from the MDC.
-                expectedMdcInfo.remove(Tracer.TRACE_ID_MDC_KEY);
-                expectedMdcInfo.remove(Tracer.SPAN_JSON_MDC_KEY);
+                expectedMdcInfo.remove(SpanFieldForLoggerMdc.TRACE_ID.mdcKey);
             }
         }
 
@@ -421,13 +420,12 @@ public class AsyncWingtipsHelperJava7Test {
                 // MDC will have been populated with tracing info.
                 expectedMdcInfo = new HashMap<>();
                 Span expectedSpan = spanStackForLinking.peek();
-                expectedMdcInfo.put(Tracer.TRACE_ID_MDC_KEY, expectedSpan.getTraceId());
-                expectedMdcInfo.put(Tracer.SPAN_JSON_MDC_KEY, expectedSpan.toJSON());
+                expectedMdcInfo.put(SpanFieldForLoggerMdc.TRACE_ID.mdcKey, expectedSpan.getTraceId());
             }
         }
         else {
             // Not null MDC. Since unlinkTracingFromCurrentThread doesn't call registerWithThread when
-            //      the span stack is null we don't need to worry about trace ID and span JSON being removed from MDC.
+            //      the span stack is null we don't need to worry about trace ID being removed from MDC.
             //      Therefore it should match mdcInfoForLinking exactly.
             expectedMdcInfo = new HashMap<>(mdcInfoForLinking);
         }

--- a/wingtips-java8/src/test/java/com/nike/wingtips/util/AsyncWingtipsHelperTest.java
+++ b/wingtips-java8/src/test/java/com/nike/wingtips/util/AsyncWingtipsHelperTest.java
@@ -3,6 +3,7 @@ package com.nike.wingtips.util;
 import com.nike.internal.util.Pair;
 import com.nike.wingtips.Span;
 import com.nike.wingtips.Tracer;
+import com.nike.wingtips.Tracer.SpanFieldForLoggerMdc;
 import com.nike.wingtips.util.asynchelperwrapper.BiConsumerWithTracing;
 import com.nike.wingtips.util.asynchelperwrapper.BiFunctionWithTracing;
 import com.nike.wingtips.util.asynchelperwrapper.BiPredicateWithTracing;
@@ -822,8 +823,7 @@ public class AsyncWingtipsHelperTest {
                 // MDC will have been populated with tracing info.
                 expectedMdcInfo = new HashMap<>();
                 Span expectedSpan = spanStackForLinking.peek();
-                expectedMdcInfo.put(Tracer.TRACE_ID_MDC_KEY, expectedSpan.getTraceId());
-                expectedMdcInfo.put(Tracer.SPAN_JSON_MDC_KEY, expectedSpan.toJSON());
+                expectedMdcInfo.put(SpanFieldForLoggerMdc.TRACE_ID.mdcKey, expectedSpan.getTraceId());
             }
         }
         else {
@@ -831,8 +831,7 @@ public class AsyncWingtipsHelperTest {
             expectedMdcInfo = new HashMap<>(mdcInfoForLinking);
             if (useNullSpanStack) {
                 // In the case of a null span stack, the trace info would be removed from the MDC.
-                expectedMdcInfo.remove(Tracer.TRACE_ID_MDC_KEY);
-                expectedMdcInfo.remove(Tracer.SPAN_JSON_MDC_KEY);
+                expectedMdcInfo.remove(SpanFieldForLoggerMdc.TRACE_ID.mdcKey);
             }
         }
 
@@ -963,13 +962,12 @@ public class AsyncWingtipsHelperTest {
                 // MDC will have been populated with tracing info.
                 expectedMdcInfo = new HashMap<>();
                 Span expectedSpan = spanStackForLinking.peek();
-                expectedMdcInfo.put(Tracer.TRACE_ID_MDC_KEY, expectedSpan.getTraceId());
-                expectedMdcInfo.put(Tracer.SPAN_JSON_MDC_KEY, expectedSpan.toJSON());
+                expectedMdcInfo.put(SpanFieldForLoggerMdc.TRACE_ID.mdcKey, expectedSpan.getTraceId());
             }
         }
         else {
             // Not null MDC. Since unlinkTracingFromCurrentThread doesn't call registerWithThread when
-            //      the span stack is null we don't need to worry about trace ID and span JSON being removed from MDC.
+            //      the span stack is null we don't need to worry about trace ID being removed from MDC.
             //      Therefore it should match mdcInfoForLinking exactly.
             expectedMdcInfo = new HashMap<>(mdcInfoForLinking);
         }


### PR DESCRIPTION
Fixes/improves the following:
* Clear cached span serializations whenever the span's state changes (including name, tag, and annotation changes).
* Remove unnecessary serializations and other processing during logging.
* Change default MDC behavior to *not* include full span JSON. Only trace ID will be included in MDC behavior by default.
* Allow users to tell `Tracer` which `Span` fields to include in the MDC behavior.