### PR TITLE
Remove HttpSpanFactory.fromHttpServletRequestOrCreateRootSpan(...)

### DIFF
--- a/wingtips-servlet-api/src/main/java/com/nike/wingtips/servlet/HttpSpanFactory.java
+++ b/wingtips-servlet-api/src/main/java/com/nike/wingtips/servlet/HttpSpanFactory.java
@@ -70,25 +70,6 @@ public class HttpSpanFactory {
     }
 
     /**
-     * @return A {@link Span} object created from the headers if they exist (see {@link #fromHttpServletRequest(HttpServletRequest, List)} for details), or if the headers don't
-     *         have enough information then this will return a new root span with a span name based on the results of {@link #getSpanName(HttpServletRequest)} and user ID based
-     *         on the result of {@link #getUserIdFromHttpServletRequest(HttpServletRequest, List)}. Since this method is for a server receiving a request
-     *         the returned span's {@link Span#getSpanPurpose()} will be {@link SpanPurpose#SERVER}.
-     */
-    public static Span fromHttpServletRequestOrCreateRootSpan(HttpServletRequest servletRequest, List<String> userIdHeaderKeys) {
-        Span span = fromHttpServletRequest(servletRequest, userIdHeaderKeys);
-
-        if (span == null) {
-            span = Span
-                .generateRootSpanForNewTrace(getSpanName(servletRequest), SpanPurpose.SERVER)
-                .withUserId(getUserIdFromHttpServletRequest(servletRequest, userIdHeaderKeys))
-                .build();
-        }
-
-        return span;
-    }
-
-    /**
      * Attempts to pull a valid ID for the user making the request.
      *
      * @return The HTTP Header value of the user ID if it exists, null otherwise. The request's headers will be inspected for the user ID using the given list of userIdHeaderKeys

--- a/wingtips-servlet-api/src/test/java/com/nike/wingtips/servlet/HttpSpanFactoryTest.java
+++ b/wingtips-servlet-api/src/test/java/com/nike/wingtips/servlet/HttpSpanFactoryTest.java
@@ -160,50 +160,6 @@ public class HttpSpanFactoryTest {
     }
 
     @Test
-    public void fromHttpServletRequestOrCreateRootSpan_pulls_from_headers_if_available() {
-        // given: a set of standard Span header values
-        given(request.getHeader(TraceHeaders.TRACE_ID)).willReturn(sampleTraceID);
-        given(request.getHeader(TraceHeaders.TRACE_SAMPLED)).willReturn(Boolean.TRUE.toString());
-        given(request.getHeader(TraceHeaders.SPAN_ID)).willReturn(sampleSpanID);
-        given(request.getHeader(TraceHeaders.PARENT_SPAN_ID)).willReturn(sampleParentSpanID);
-        given(request.getHeader(USER_ID_HEADER_KEY)).willReturn(userId);
-
-        // when: creating Span object from HTTP request using fromHttpServletRequestOrCreateRootSpan
-        long beforeCallNanos = System.nanoTime();
-        Span goodSpan = HttpSpanFactory.fromHttpServletRequestOrCreateRootSpan(request, USER_ID_HEADER_KEYS);
-        long afterCallNanos = System.nanoTime();
-
-        // then: ensure Span object gets identical values from corresponding headers
-        assertThat(goodSpan.getTraceId()).isEqualTo(sampleTraceID);
-        assertThat(goodSpan.isSampleable()).isTrue();
-        assertThat(goodSpan.getSpanId()).isEqualTo(sampleSpanID);
-        assertThat(goodSpan.getParentSpanId()).isEqualTo(sampleParentSpanID);
-        assertThat(goodSpan.getUserId()).isEqualTo(userId);
-        assertThat(goodSpan.getSpanStartTimeNanos()).isBetween(beforeCallNanos, afterCallNanos);
-        assertThat(goodSpan.isCompleted()).isFalse();
-        assertThat(goodSpan.getSpanPurpose()).isEqualTo(SpanPurpose.CLIENT);
-    }
-
-    @Test
-    public void fromHttpServletRequestOrCreateRootSpan_returns_new_root_span_if_traceId_is_missing_from_headers() {
-        // given: no trace ID in headers, but user ID exists
-        given(request.getHeader(ALT_USER_ID_HEADER_KEY)).willReturn(altUserId);
-
-        // when: creating Span object from HTTP request using fromHttpServletRequestOrCreateRootSpan
-        long beforeCallNanos = System.nanoTime();
-        Span newSpan = HttpSpanFactory.fromHttpServletRequestOrCreateRootSpan(request, USER_ID_HEADER_KEYS);
-        long afterCallNanos = System.nanoTime();
-
-        // then: ensure root span object is created even though there was no trace ID header, and the returned span contains the expected user ID
-        assertThat(newSpan).isNotNull();
-        assertThat(newSpan.getParentSpanId()).isNull();
-        assertThat(newSpan.getUserId()).isEqualTo(altUserId);
-        assertThat(newSpan.getSpanStartTimeNanos()).isBetween(beforeCallNanos, afterCallNanos);
-        assertThat(newSpan.isCompleted()).isFalse();
-        assertThat(newSpan.getSpanPurpose()).isEqualTo(SpanPurpose.SERVER);
-    }
-
-    @Test
     public void fromHttpServletRequest_returns_null_if_passed_null_request() {
         // when
         Span nullSpan = HttpSpanFactory.fromHttpServletRequest(null, USER_ID_HEADER_KEYS);


### PR DESCRIPTION
This `HttpSpanFactory.fromHttpServletRequestOrCreateRootSpan(...)` method is a bad mix of two competing use cases:
* If the request contains tracing headers, then the returned span is a synthetic span represents the caller's (client) span. It should not be used directly.
* If the request is missing tracing headers, then the returned span represents a new trace for the server's overall request span, and should be used directly.

i.e. This method is guaranteed to do the wrong thing at some point no matter what you're trying to use it for.

I don't believe anybody is using this method, but if they are, then they need to rethink what they're trying to use it for and do the right thing instead.

The release notes for the next version will communicate this breaking change and what users should do about it if they're affected.