### PR TITLE
Adds tracing support to async boundaries in reactor-core

### DIFF
--- a/wingtips-core/src/main/java/com/nike/wingtips/util/asynchelperwrapper/ScheduledExecutorServiceWithTracing.java
+++ b/wingtips-core/src/main/java/com/nike/wingtips/util/asynchelperwrapper/ScheduledExecutorServiceWithTracing.java
@@ -1,0 +1,90 @@
+package com.nike.wingtips.util.asynchelperwrapper;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A wrapper around any {@link ScheduledExecutorService} instance that causes the current (method caller's) tracing
+ * state to hop
+ * threads when {@link Runnable}s or {@link Callable}s are supplied for execution. Simply supply the constructor with
+ * the delegate {@link ScheduledExecutorService} you want to wrap (often one from {@link java.util.concurrent.Executors}) and
+ * then treat it like any other {@link ScheduledExecutorService}. Shutdown and termination methods pass through to the
+ * delegate - {@link ScheduledExecutorServiceWithTracing} does not contain any state of its own.
+ *
+ *
+ * <p>Usage:
+ * <pre>
+ * // In some setup location, create the ScheduledExecutorWithTracing.
+ * ScheduledExecutorService tracingAwareScheduledExecutorService =
+ *                          new ScheduledExecutorWithTracing(Executors.newSingleThreadScheduledExecutor());
+ *
+ *
+ * // Elsewhere, setup the tracing state for the caller's thread.
+ * Tracer.getInstance().startRequestWithRootSpan("someRootSpan");
+ * TracingState callerThreadTracingState = TracingState.getCurrentThreadTracingState();
+ *
+ * // Tell the tracing-wrapped executor to execute a Runnable.
+ * tracingAwareExecutorService.execute(() -> {
+ *     // Runnable's execution code goes here.
+ *     // The important bit is that although we are no longer on the caller's thread, this Runnable's thread
+ *     //     will have the same tracing state as the caller. The following line will not throw an exception.
+ *     assert callerThreadTracingState.equals(TracingState.getCurrentThreadTracingState());
+ * });
+ * </pre>
+ *
+ * @author Biju Kunjummen
+ * @author Rafaela Breed
+ */
+public class ScheduledExecutorServiceWithTracing extends ExecutorServiceWithTracing implements ScheduledExecutorService {
+
+    protected final ScheduledExecutorService delegate;
+
+    /**
+     * Creates a new instance that wraps the given delegate {@link ScheduledExecutorService} so that when
+     * {@link Runnable}s
+     * or {@link Callable}s are executed they will automatically inherit the tracing state of the thread that called
+     * the {@link ScheduledExecutorService} method.
+     *
+     * @param delegate The {@link ScheduledExecutorService} to delegate all calls to.
+     */
+    public ScheduledExecutorServiceWithTracing(ScheduledExecutorService delegate) {
+        super(delegate);
+        this.delegate = delegate;
+    }
+
+    /**
+     * Factory method that creates a new instance that wraps the given delegate {@link ScheduledExecutorService} so
+     * that when
+     * {@link Runnable}s or {@link Callable}s are executed they will automatically inherit the tracing state of the
+     * thread that called the {@link ScheduledExecutorService} method. Equivalent to calling:
+     * {@code new ScheduledExecutorWithTracing(delegate)}.
+     *
+     * @param delegate The {@link ScheduledExecutorService} to delegate all calls to.
+     * @return {@code new ScheduledExecutorWithTracing(delegate)}
+     */
+    public static ScheduledExecutorServiceWithTracing withTracing(ScheduledExecutorService delegate) {
+        return new ScheduledExecutorServiceWithTracing(delegate);
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return delegate.schedule(new RunnableWithTracing(command), delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return this.delegate.schedule(new CallableWithTracing<>(callable), delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return this.delegate.scheduleAtFixedRate(new RunnableWithTracing(command), initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return this.delegate.scheduleWithFixedDelay(new RunnableWithTracing(command), initialDelay, delay, unit);
+    }
+}

--- a/wingtips-core/src/test/java/com/nike/wingtips/util/asynchelperwrapper/ScheduledExecutorServiceWithTracingTest.java
+++ b/wingtips-core/src/test/java/com/nike/wingtips/util/asynchelperwrapper/ScheduledExecutorServiceWithTracingTest.java
@@ -1,0 +1,633 @@
+package com.nike.wingtips.util.asynchelperwrapper;
+
+import com.nike.wingtips.Span;
+import com.nike.wingtips.Span.SpanPurpose;
+import com.nike.wingtips.Tracer;
+import com.nike.wingtips.util.TracingState;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.MDC;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.nike.wingtips.util.asynchelperwrapper.ScheduledExecutorServiceWithTracing.withTracing;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * Tests the functionality of {@link ScheduledExecutorServiceWithTracing}.
+ *
+ * @author Biju Kunjummen
+ * @author Rafaela Breed
+ */
+@RunWith(DataProviderRunner.class)
+public class ScheduledExecutorServiceWithTracingTest {
+
+    private ScheduledExecutorService executorServiceMock;
+    private ScheduledExecutorServiceWithTracing instance;
+
+    private ArgumentCaptor<Callable> callableCaptor;
+    private ArgumentCaptor<Runnable> runnableCaptor;
+    private ArgumentCaptor<Collection> collectionCaptor;
+
+    @Before
+    public void beforeMethod() {
+        executorServiceMock = mock(ScheduledExecutorService.class);
+        instance = new ScheduledExecutorServiceWithTracing(executorServiceMock);
+
+        callableCaptor = ArgumentCaptor.forClass(Callable.class);
+        runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        collectionCaptor = ArgumentCaptor.forClass(Collection.class);
+
+        resetTracing();
+    }
+
+    @After
+    public void afterMethod() {
+        resetTracing();
+    }
+
+    private void resetTracing() {
+        MDC.clear();
+        Tracer.getInstance().unregisterFromThread();
+    }
+
+    @DataProvider(value = {
+        "true",
+        "false"
+    })
+    @Test
+    public void constructor_sets_fields_as_expected(boolean useStaticFactoryMethod) {
+        // given
+        executorServiceMock = mock(ScheduledExecutorService.class);
+
+        // when
+        instance = (useStaticFactoryMethod)
+                   ? withTracing(executorServiceMock)
+                   : new ScheduledExecutorServiceWithTracing(executorServiceMock);
+
+        // then
+        assertThat(instance.delegate).isSameAs(executorServiceMock);
+    }
+
+    @Test
+    public void shutdown_passes_through_to_delegate() {
+        // when
+        instance.shutdown();
+
+        // then
+        verify(executorServiceMock).shutdown();
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void shutdownNow_passes_through_to_delegate() {
+        // when
+        instance.shutdownNow();
+
+        // then
+        verify(executorServiceMock).shutdownNow();
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @DataProvider(value = {
+        "true",
+        "false"
+    })
+    @Test
+    public void isShutdown_passes_through_to_delegate(boolean delegateValue) {
+        // given
+        doReturn(delegateValue).when(executorServiceMock).isShutdown();
+
+        // when
+        boolean result = instance.isShutdown();
+
+        // then
+        assertThat(result).isEqualTo(delegateValue);
+        verify(executorServiceMock).isShutdown();
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @DataProvider(value = {
+        "true",
+        "false"
+    })
+    @Test
+    public void isTerminated_passes_through_to_delegate(boolean delegateValue) {
+        // given
+        doReturn(delegateValue).when(executorServiceMock).isTerminated();
+
+        // when
+        boolean result = instance.isTerminated();
+
+        // then
+        assertThat(result).isEqualTo(delegateValue);
+        verify(executorServiceMock).isTerminated();
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @DataProvider(value = {
+        "true",
+        "false"
+    })
+    @Test
+    public void awaitTermination_passes_through_to_delegate(boolean delegateValue) throws InterruptedException {
+        // given
+        long timeoutValue = 42;
+        TimeUnit timeoutTimeUnit = TimeUnit.MINUTES;
+        doReturn(delegateValue).when(executorServiceMock).awaitTermination(anyLong(), any(TimeUnit.class));
+
+        // when
+        boolean result = instance.awaitTermination(timeoutValue, timeoutTimeUnit);
+
+        // then
+        assertThat(result).isEqualTo(delegateValue);
+        verify(executorServiceMock).awaitTermination(timeoutValue, timeoutTimeUnit);
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void submit_callable_passes_through_to_delegate_with_tracing_wrapper() {
+        // given
+        Callable<?> origTaskMock = mock(Callable.class);
+        Future<?> expectedResultMock = mock(Future.class);
+        doReturn(expectedResultMock).when(executorServiceMock).submit(any(Callable.class));
+
+        TracingState expectedTracingState = generateTracingStateOnCurrentThread();
+
+        // when
+        Future<?> result = instance.submit(origTaskMock);
+
+        // then
+        assertThat(result).isSameAs(expectedResultMock);
+        verify(executorServiceMock).submit(callableCaptor.capture());
+        Callable<?> actualTask = callableCaptor.getValue();
+        verifyCallableWithTracingWrapper(actualTask, origTaskMock, expectedTracingState);
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void schedule_callable_passes_through_to_delegate_with_tracing_wrapper() {
+        // given
+        Callable<?> origTaskMock = mock(Callable.class);
+        ScheduledFuture<?> expectedResultMock = mock(ScheduledFuture.class);
+        doReturn(expectedResultMock).when(executorServiceMock).schedule(any(Callable.class), anyLong(), any(TimeUnit.class));
+
+        TracingState expectedTracingState = generateTracingStateOnCurrentThread();
+
+        // when
+        Future<?> result = instance.schedule(origTaskMock, 10L, TimeUnit.SECONDS);
+
+        // then
+        assertThat(result).isSameAs(expectedResultMock);
+        verify(executorServiceMock).schedule(callableCaptor.capture(), eq(10L), eq(TimeUnit.SECONDS));
+        Callable<?> actualTask = callableCaptor.getValue();
+        verifyCallableWithTracingWrapper(actualTask, origTaskMock, expectedTracingState);
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    private TracingState generateTracingStateOnCurrentThread() {
+        Tracer.getInstance().startRequestWithRootSpan(UUID.randomUUID().toString());
+        Tracer.getInstance().startSubSpan(UUID.randomUUID().toString(), SpanPurpose.LOCAL_ONLY);
+        return TracingState.getCurrentThreadTracingState();
+    }
+
+    private void verifyCallableWithTracingWrapper(
+        Callable<?> actual, Callable<?> expectedOrigCallable, TracingState expectedTracingState
+    ) {
+        assertThat(actual).isInstanceOf(CallableWithTracing.class);
+        CallableWithTracing<?> actualWithTracing = (CallableWithTracing<?>) actual;
+        assertThat(actualWithTracing.origCallable).isSameAs(expectedOrigCallable);
+        verifyExpectedTracingState(
+            actualWithTracing.spanStackForExecution, actualWithTracing.mdcContextMapForExecution, expectedTracingState
+        );
+    }
+
+    private void verifyExpectedTracingState(
+        Deque<Span> actualSpanStack, Map<String, String> actualMdc, TracingState expectedTracingState
+    ) {
+        assertThat(actualSpanStack).isEqualTo(expectedTracingState.spanStack);
+        assertThat(actualMdc).isEqualTo(expectedTracingState.mdcInfo);
+    }
+
+    @Test
+    public void submit_runnable_with_result_passes_through_to_delegate_with_tracing_wrapper() {
+        // given
+        Runnable origTaskMock = mock(Runnable.class);
+        String resultArg = UUID.randomUUID().toString();
+        Future<String> expectedResultMock = mock(Future.class);
+        doReturn(expectedResultMock).when(executorServiceMock).submit(any(Runnable.class), anyString());
+
+        TracingState expectedTracingState = generateTracingStateOnCurrentThread();
+
+        // when
+        Future<String> result = instance.submit(origTaskMock, resultArg);
+
+        // then
+        assertThat(result).isSameAs(expectedResultMock);
+        verify(executorServiceMock).submit(runnableCaptor.capture(), eq(resultArg));
+        Runnable actualTask = runnableCaptor.getValue();
+        verifyRunnableWithTracingWrapper(actualTask, origTaskMock, expectedTracingState);
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void schedule_runnable_with_delay_passes_through_to_delegate_with_tracing_wrapper() {
+        // given
+        Runnable origTaskMock = mock(Runnable.class);
+        ScheduledFuture<?> expectedResultMock = mock(ScheduledFuture.class);
+        doReturn(expectedResultMock).when(executorServiceMock).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+
+        TracingState expectedTracingState = generateTracingStateOnCurrentThread();
+
+        // when
+        ScheduledFuture<?> result = instance.schedule(origTaskMock, 10L, TimeUnit.SECONDS);
+
+        // then
+        assertThat(result).isSameAs(expectedResultMock);
+        verify(executorServiceMock).schedule(runnableCaptor.capture(), eq(10L), eq(TimeUnit.SECONDS));
+        Runnable actualTask = runnableCaptor.getValue();
+        verifyRunnableWithTracingWrapper(actualTask, origTaskMock, expectedTracingState);
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void schedule_runnable_at_fixed_rate_passes_through_to_delegate_with_tracing_wrapper() {
+        // given
+        Runnable origTaskMock = mock(Runnable.class);
+        ScheduledFuture<?> expectedResultMock = mock(ScheduledFuture.class);
+        doReturn(expectedResultMock).when(executorServiceMock)
+                .scheduleAtFixedRate(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+
+        TracingState expectedTracingState = generateTracingStateOnCurrentThread();
+
+        // when
+        ScheduledFuture<?> result = instance.scheduleAtFixedRate(origTaskMock, 10L, 10L, TimeUnit.SECONDS);
+
+        // then
+        assertThat(result).isSameAs(expectedResultMock);
+        verify(executorServiceMock).scheduleAtFixedRate(runnableCaptor.capture(), eq(10L), eq(10L), eq(TimeUnit.SECONDS));
+        Runnable actualTask = runnableCaptor.getValue();
+        verifyRunnableWithTracingWrapper(actualTask, origTaskMock, expectedTracingState);
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void schedule_runnable_with_fixed_delay_passes_through_to_delegate_with_tracing_wrapper() {
+        // given
+        Runnable origTaskMock = mock(Runnable.class);
+        ScheduledFuture<?> expectedResultMock = mock(ScheduledFuture.class);
+        doReturn(expectedResultMock).when(executorServiceMock)
+                .scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+
+        TracingState expectedTracingState = generateTracingStateOnCurrentThread();
+
+        // when
+        ScheduledFuture<?> result = instance.scheduleWithFixedDelay(origTaskMock, 10L, 10L, TimeUnit.SECONDS);
+
+        // then
+        assertThat(result).isSameAs(expectedResultMock);
+        verify(executorServiceMock).scheduleWithFixedDelay(runnableCaptor.capture(), eq(10L), eq(10L), eq(TimeUnit.SECONDS));
+        Runnable actualTask = runnableCaptor.getValue();
+        verifyRunnableWithTracingWrapper(actualTask, origTaskMock, expectedTracingState);
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+
+    private void verifyRunnableWithTracingWrapper(
+        Runnable actual, Runnable expectedOrigRunnable, TracingState expectedTracingState
+    ) {
+        assertThat(actual).isInstanceOf(RunnableWithTracing.class);
+        RunnableWithTracing actualWithTracing = (RunnableWithTracing) actual;
+        assertThat(actualWithTracing.origRunnable).isSameAs(expectedOrigRunnable);
+        verifyExpectedTracingState(
+            actualWithTracing.spanStackForExecution, actualWithTracing.mdcContextMapForExecution, expectedTracingState
+        );
+    }
+
+    @Test
+    public void submit_runnable_passes_through_to_delegate_with_tracing_wrapper() {
+        // given
+        Runnable origTaskMock = mock(Runnable.class);
+        Future<?> expectedResultMock = mock(Future.class);
+        doReturn(expectedResultMock).when(executorServiceMock).submit(any(Runnable.class));
+
+        TracingState expectedTracingState = generateTracingStateOnCurrentThread();
+
+        // when
+        Future<?> result = instance.submit(origTaskMock);
+
+        // then
+        assertThat(result).isSameAs(expectedResultMock);
+        verify(executorServiceMock).submit(runnableCaptor.capture());
+        Runnable actualTask = runnableCaptor.getValue();
+        verifyRunnableWithTracingWrapper(actualTask, origTaskMock, expectedTracingState);
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void invokeAll_no_timeout_passes_through_to_delegate_with_tracing_wrapped_tasks()
+        throws InterruptedException {
+        // given
+        List<Callable<Object>> origTasks = Arrays.asList(mock(Callable.class), mock(Callable.class));
+        List<Future<Object>> expectedResultMock = mock(List.class);
+        doReturn(expectedResultMock).when(executorServiceMock).invokeAll(any(Collection.class));
+
+        TracingState expectedTracingState = generateTracingStateOnCurrentThread();
+
+        // when
+        List<Future<Object>> result = instance.invokeAll(origTasks);
+
+        // then
+        assertThat(result).isSameAs(expectedResultMock);
+        verify(executorServiceMock).invokeAll(collectionCaptor.capture());
+        List<Callable<Object>> actualTasks = (List<Callable<Object>>) collectionCaptor.getValue();
+        assertThat(actualTasks).hasSameSizeAs(origTasks);
+        for (int i = 0; i < actualTasks.size(); i++) {
+            Callable<Object> actualTask = actualTasks.get(i);
+            Callable<Object> origTaskMock = origTasks.get(i);
+            verifyCallableWithTracingWrapper(actualTask, origTaskMock, expectedTracingState);
+        }
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void invokeAll_no_timeout_uses_convertToCallableWithTracingList_to_convert_tasks()
+        throws InterruptedException {
+        // given
+        ExecutorServiceWithTracing instanceSpy = spy(instance);
+
+        List<Callable<Object>> origTasks = Arrays.asList(mock(Callable.class), mock(Callable.class));
+
+        List<Callable<Object>> convertMethodResult = mock(List.class);
+        doReturn(convertMethodResult).when(instanceSpy).convertToCallableWithTracingList(any(Collection.class));
+
+        List<Future<Object>> expectedResultMock = mock(List.class);
+        doReturn(expectedResultMock).when(executorServiceMock).invokeAll(any(Collection.class));
+
+        // when
+        List<Future<Object>> result = instanceSpy.invokeAll(origTasks);
+
+        // then
+        assertThat(result).isSameAs(expectedResultMock);
+        verify(instanceSpy).convertToCallableWithTracingList(origTasks);
+        verify(executorServiceMock).invokeAll(convertMethodResult);
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void invokeAll_with_timeout_passes_through_to_delegate_with_tracing_wrapped_tasks()
+        throws InterruptedException {
+        // given
+        List<Callable<Object>> origTasks = Arrays.asList(mock(Callable.class), mock(Callable.class));
+        List<Future<Object>> expectedResultMock = mock(List.class);
+        doReturn(expectedResultMock).when(executorServiceMock)
+                                    .invokeAll(any(Collection.class), anyLong(), any(TimeUnit.class));
+
+        long timeoutValue = 42;
+        TimeUnit timeoutTimeUnit = TimeUnit.MINUTES;
+
+        TracingState expectedTracingState = generateTracingStateOnCurrentThread();
+
+        // when
+        List<Future<Object>> result = instance.invokeAll(origTasks, timeoutValue, timeoutTimeUnit);
+
+        // then
+        assertThat(result).isSameAs(expectedResultMock);
+        verify(executorServiceMock).invokeAll(collectionCaptor.capture(), eq(timeoutValue), eq(timeoutTimeUnit));
+        List<Callable<Object>> actualTasks = (List<Callable<Object>>) collectionCaptor.getValue();
+        assertThat(actualTasks).hasSameSizeAs(origTasks);
+        for (int i = 0; i < actualTasks.size(); i++) {
+            Callable<Object> actualTask = actualTasks.get(i);
+            Callable<Object> origTaskMock = origTasks.get(i);
+            verifyCallableWithTracingWrapper(actualTask, origTaskMock, expectedTracingState);
+        }
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void invokeAll_with_timeout_uses_convertToCallableWithTracingList_to_convert_tasks()
+        throws InterruptedException {
+        // given
+        ExecutorServiceWithTracing instanceSpy = spy(instance);
+
+        List<Callable<Object>> origTasks = Arrays.asList(mock(Callable.class), mock(Callable.class));
+
+        List<Callable<Object>> convertMethodResult = mock(List.class);
+        doReturn(convertMethodResult).when(instanceSpy).convertToCallableWithTracingList(any(Collection.class));
+
+        List<Future<Object>> expectedResultMock = mock(List.class);
+        doReturn(expectedResultMock).when(executorServiceMock)
+                                    .invokeAll(any(Collection.class), anyLong(), any(TimeUnit.class));
+
+        long timeoutValue = 42;
+        TimeUnit timeoutTimeUnit = TimeUnit.MINUTES;
+
+        // when
+        List<Future<Object>> result = instanceSpy.invokeAll(origTasks, timeoutValue, timeoutTimeUnit);
+
+        // then
+        assertThat(result).isSameAs(expectedResultMock);
+        verify(instanceSpy).convertToCallableWithTracingList(origTasks);
+        verify(executorServiceMock).invokeAll(convertMethodResult, timeoutValue, timeoutTimeUnit);
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void invokeAny_no_timeout_passes_through_to_delegate_with_tracing_wrapped_tasks()
+        throws InterruptedException, ExecutionException {
+        // given
+        List<Callable<Object>> origTasks = Arrays.asList(mock(Callable.class), mock(Callable.class));
+        Object expectedResultMock = mock(Object.class);
+        doReturn(expectedResultMock).when(executorServiceMock).invokeAny(any(Collection.class));
+
+        TracingState expectedTracingState = generateTracingStateOnCurrentThread();
+
+        // when
+        Object result = instance.invokeAny(origTasks);
+
+        // then
+        assertThat(result).isSameAs(expectedResultMock);
+        verify(executorServiceMock).invokeAny(collectionCaptor.capture());
+        List<Callable<Object>> actualTasks = (List<Callable<Object>>) collectionCaptor.getValue();
+        assertThat(actualTasks).hasSameSizeAs(origTasks);
+        for (int i = 0; i < actualTasks.size(); i++) {
+            Callable<Object> actualTask = actualTasks.get(i);
+            Callable<Object> origTaskMock = origTasks.get(i);
+            verifyCallableWithTracingWrapper(actualTask, origTaskMock, expectedTracingState);
+        }
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void invokeAny_no_timeout_uses_convertToCallableWithTracingList_to_convert_tasks()
+        throws InterruptedException, ExecutionException {
+        // given
+        ExecutorServiceWithTracing instanceSpy = spy(instance);
+
+        List<Callable<Object>> origTasks = Arrays.asList(mock(Callable.class), mock(Callable.class));
+
+        List<Callable<Object>> convertMethodResult = mock(List.class);
+        doReturn(convertMethodResult).when(instanceSpy).convertToCallableWithTracingList(any(Collection.class));
+
+        Object expectedResultMock = mock(Object.class);
+        doReturn(expectedResultMock).when(executorServiceMock).invokeAny(any(Collection.class));
+
+        // when
+        Object result = instanceSpy.invokeAny(origTasks);
+
+        // then
+        assertThat(result).isSameAs(expectedResultMock);
+        verify(instanceSpy).convertToCallableWithTracingList(origTasks);
+        verify(executorServiceMock).invokeAny(convertMethodResult);
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void invokeAny_with_timeout_passes_through_to_delegate_with_tracing_wrapped_tasks()
+        throws InterruptedException, TimeoutException, ExecutionException {
+        // given
+        List<Callable<Object>> origTasks = Arrays.asList(mock(Callable.class), mock(Callable.class));
+        Object expectedResultMock = mock(Object.class);
+        doReturn(expectedResultMock).when(executorServiceMock)
+                                    .invokeAny(any(Collection.class), anyLong(), any(TimeUnit.class));
+
+        long timeoutValue = 42;
+        TimeUnit timeoutTimeUnit = TimeUnit.MINUTES;
+
+        TracingState expectedTracingState = generateTracingStateOnCurrentThread();
+
+        // when
+        Object result = instance.invokeAny(origTasks, timeoutValue, timeoutTimeUnit);
+
+        // then
+        assertThat(result).isSameAs(expectedResultMock);
+        verify(executorServiceMock).invokeAny(collectionCaptor.capture(), eq(timeoutValue), eq(timeoutTimeUnit));
+        List<Callable<Object>> actualTasks = (List<Callable<Object>>) collectionCaptor.getValue();
+        assertThat(actualTasks).hasSameSizeAs(origTasks);
+        for (int i = 0; i < actualTasks.size(); i++) {
+            Callable<Object> actualTask = actualTasks.get(i);
+            Callable<Object> origTaskMock = origTasks.get(i);
+            verifyCallableWithTracingWrapper(actualTask, origTaskMock, expectedTracingState);
+        }
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void invokeAny_with_timeout_uses_convertToCallableWithTracingList_to_convert_tasks()
+        throws InterruptedException, TimeoutException, ExecutionException {
+        // given
+        ExecutorServiceWithTracing instanceSpy = spy(instance);
+        List<Callable<Object>> origTasks = Arrays.asList(mock(Callable.class), mock(Callable.class));
+        List<Callable<Object>> convertMethodResult = mock(List.class);
+        doReturn(convertMethodResult).when(instanceSpy).convertToCallableWithTracingList(any(Collection.class));
+
+        Object expectedResultMock = mock(Object.class);
+        doReturn(expectedResultMock).when(executorServiceMock)
+                                    .invokeAny(any(Collection.class), anyLong(), any(TimeUnit.class));
+
+        long timeoutValue = 42;
+        TimeUnit timeoutTimeUnit = TimeUnit.MINUTES;
+
+        // when
+        Object result = instanceSpy.invokeAny(origTasks, timeoutValue, timeoutTimeUnit);
+
+        // then
+        assertThat(result).isSameAs(expectedResultMock);
+        verify(instanceSpy).convertToCallableWithTracingList(origTasks);
+        verify(executorServiceMock).invokeAny(convertMethodResult, timeoutValue, timeoutTimeUnit);
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void execute_passes_through_to_delegate_with_tracing_wrapped_runnable() {
+        // given
+        Runnable origRunnableMock = mock(Runnable.class);
+
+        TracingState expectedTracingState = generateTracingStateOnCurrentThread();
+
+        // when
+        instance.execute(origRunnableMock);
+
+        // then
+        verify(executorServiceMock).execute(runnableCaptor.capture());
+        Runnable actualRunnable = runnableCaptor.getValue();
+        verifyRunnableWithTracingWrapper(actualRunnable, origRunnableMock, expectedTracingState);
+
+        verifyNoMoreInteractions(executorServiceMock);
+    }
+
+    @Test
+    public void convertToCallableWithTracingList_works_as_expected() {
+        // given
+        List<Callable<Object>> origCallables = Arrays.asList(
+            mock(Callable.class),
+            null,
+            mock(Callable.class)
+        );
+        TracingState expectedTracingState = generateTracingStateOnCurrentThread();
+
+        // when
+        List<Callable<Object>> results = instance.convertToCallableWithTracingList(origCallables);
+
+        // then
+        assertThat(results).hasSameSizeAs(origCallables);
+        for (int i = 0; i < results.size(); i++) {
+            Callable<Object> actualTask = results.get(i);
+            Callable<Object> origTaskMock = origCallables.get(i);
+            if (origTaskMock == null) {
+                assertThat(actualTask).isNull();
+            }
+            else {
+                verifyCallableWithTracingWrapper(actualTask, origTaskMock, expectedTracingState);
+            }
+        }
+    }
+
+    @Test
+    public void convertToCallableWithTracingList_returns_null_if_passed_null() {
+        // expect
+        assertThat(instance.convertToCallableWithTracingList(null)).isNull();
+    }
+
+}

--- a/wingtips-spring-boot2-webflux/README.md
+++ b/wingtips-spring-boot2-webflux/README.md
@@ -39,6 +39,7 @@ for the remaining properties:
 
 ``` ini
 wingtips.wingtips-disabled=false
+wingtips.reactor-enabled=true
 wingtips.user-id-header-keys=userid,altuserid
 wingtips.span-logging-format=KEY_VALUE
 wingtips.server-side-span-tagging-strategy=ZIPKIN
@@ -64,7 +65,10 @@ properties to set up the following Wingtips features:
     name spans and tag spans with useful metadata about the request and response. By default it will use 
     `ZipkinHttpTagStrategy` and `SpringWebfluxServerRequestTagAdapter`. To modify the tag strategy and/or adapter, you 
     can set the `wingtips.server-side-span-tagging-strategy` and/or `wingtips.server-side-span-tagging-adapter` 
-    application properties (see `WingtipsSpringBoot2WebfluxProperties` description below). 
+    application properties (see `WingtipsSpringBoot2WebfluxProperties` description below).
+    - Adds a hook that enables Wingtips tracing to span async boundaries when using [Project Reactors](https://projectreactor.io/) 
+    `Mono` and `Flux` types along with `subscribeOn` and `publishOn` operators.
+       
 * **`WingtipsSpringBoot2WebfluxProperties`** - The Spring Boot 
 [@ConfigurationProperties](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-typesafe-configuration-properties) 
 companion for `WingtipsSpringBoot2WebfluxConfiguration` (described above) that allows you to customize some Wingtips 
@@ -74,6 +78,9 @@ for a concrete example. The following properties are supported (all of them opti
     - **`wingtips.wingtips-disabled`** - Disables the Wingtips `WingtipsSpringWebfluxWebFilter` filter if and 
     only if this property value is set to true. If false or missing then `WingtipsSpringWebfluxWebFilter` will be 
     registered normally.
+    - **`wingtips.reactor-enabled`** - Enables support for Wingtips tracing across Project reactors async boundaries. 
+    The property is disabled by default.
+
     - **`wingtips.user-id-header-keys`** - Used to specify the user ID header keys that Wingtips will look for on 
     incoming headers. See the `userIdHeaderKeys` parameter javadocs for the 
     `HttpRequestTracingUtils.fromRequestWithHeaders(...)` method for more info. This is optional - if not specified 

--- a/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsReactorConfiguration.java
+++ b/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsReactorConfiguration.java
@@ -1,0 +1,49 @@
+package com.nike.wingtips.springboot2.webflux;
+
+import com.nike.wingtips.util.asynchelperwrapper.ScheduledExecutorServiceWithTracing;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * This configuration registers a reactor-core {@link reactor.core.scheduler.Scheduler}
+ * hook, which ensures that Wingtip trace spans {@link reactor.core.publisher.Mono}
+ * and {@link reactor.core.publisher.Flux} based async boundaries.
+ *
+ * @author Biju Kunjummen
+ * @author Rafaela Breed
+ */
+@Configuration
+public class WingtipsReactorConfiguration {
+
+    @Bean
+    public WingtipsReactorInitializer reactorInitializer() {
+        return new WingtipsReactorInitializer();
+    }
+}
+
+/**
+ * Spring {@link ApplicationListener} responsible for initializing reactors scheduler hook
+ * with wingtips support at a Spring Boot Application Startup
+ */
+
+class WingtipsReactorInitializer implements ApplicationListener<ApplicationReadyEvent> {
+    private static final String WINGTIPS_SCHEDULER_KEY = "WINGTIPS_REACTOR";
+
+    /**
+     * Register a {@link reactor.core.scheduler.Scheduler} hook when
+     * a Spring Boot application is ready,
+     * that ensures that when a thread is borrowed, tracing details
+     * are propagated to the thread
+     *
+     * @param event
+     */
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        Schedulers.addExecutorServiceDecorator(
+                WINGTIPS_SCHEDULER_KEY,
+                (scheduler, schedulerService) -> new ScheduledExecutorServiceWithTracing(schedulerService));
+    }
+}

--- a/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsReactorInitializer.java
+++ b/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsReactorInitializer.java
@@ -13,7 +13,7 @@ import reactor.core.scheduler.Schedulers;
  */
 
 class WingtipsReactorInitializer implements ApplicationListener<ApplicationReadyEvent> {
-    private static final String WINGTIPS_SCHEDULER_KEY = "WINGTIPS_REACTOR";
+    static final String WINGTIPS_SCHEDULER_KEY = "WINGTIPS_REACTOR";
 
     /**
      * Register a {@link reactor.core.scheduler.Scheduler} hook when

--- a/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsReactorInitializer.java
+++ b/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsReactorInitializer.java
@@ -3,30 +3,13 @@ package com.nike.wingtips.springboot2.webflux;
 import com.nike.wingtips.util.asynchelperwrapper.ScheduledExecutorServiceWithTracing;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import reactor.core.scheduler.Schedulers;
-
-/**
- * This configuration registers a reactor-core {@link reactor.core.scheduler.Scheduler}
- * hook, which ensures that Wingtip trace spans {@link reactor.core.publisher.Mono}
- * and {@link reactor.core.publisher.Flux} based async boundaries.
- *
- * @author Biju Kunjummen
- * @author Rafaela Breed
- */
-@Configuration
-public class WingtipsReactorConfiguration {
-
-    @Bean
-    public WingtipsReactorInitializer reactorInitializer() {
-        return new WingtipsReactorInitializer();
-    }
-}
 
 /**
  * Spring {@link ApplicationListener} responsible for initializing reactors scheduler hook
  * with wingtips support at a Spring Boot Application Startup
+ * @author Biju Kunjummen
+ * @author Rafaela Breed
  */
 
 class WingtipsReactorInitializer implements ApplicationListener<ApplicationReadyEvent> {

--- a/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsReactorInitializer.java
+++ b/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsReactorInitializer.java
@@ -8,12 +8,18 @@ import reactor.core.scheduler.Schedulers;
 /**
  * Spring {@link ApplicationListener} responsible for initializing reactors scheduler hook
  * with wingtips support at a Spring Boot Application Startup
+ *
  * @author Biju Kunjummen
  * @author Rafaela Breed
  */
 
 class WingtipsReactorInitializer implements ApplicationListener<ApplicationReadyEvent> {
     static final String WINGTIPS_SCHEDULER_KEY = "WINGTIPS_REACTOR";
+    private final boolean enabled;
+
+    public WingtipsReactorInitializer(boolean enabled) {
+        this.enabled = enabled;
+    }
 
     /**
      * Register a {@link reactor.core.scheduler.Scheduler} hook when
@@ -25,8 +31,10 @@ class WingtipsReactorInitializer implements ApplicationListener<ApplicationReady
      */
     @Override
     public void onApplicationEvent(ApplicationReadyEvent event) {
-        Schedulers.addExecutorServiceDecorator(
-                WINGTIPS_SCHEDULER_KEY,
-                (scheduler, schedulerService) -> new ScheduledExecutorServiceWithTracing(schedulerService));
+        if (enabled) {
+            Schedulers.addExecutorServiceDecorator(
+                    WINGTIPS_SCHEDULER_KEY,
+                    (scheduler, schedulerService) -> new ScheduledExecutorServiceWithTracing(schedulerService));
+        }
     }
 }

--- a/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsSpringBoot2WebfluxConfiguration.java
+++ b/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsSpringBoot2WebfluxConfiguration.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -139,8 +140,11 @@ public class WingtipsSpringBoot2WebfluxConfiguration {
      * and {@link reactor.core.publisher.Flux} based async boundaries.
      */
     @Bean
-    public WingtipsReactorInitializer reactorInitializer() {
-        return new WingtipsReactorInitializer();
+    public WingtipsReactorInitializer reactorInitializer(WingtipsSpringBoot2WebfluxProperties props) {
+        if (props.isReactorEnabled()) {
+            return new WingtipsReactorInitializer();
+        }
+        return null;
     }
 
     protected @Nullable List<String> extractUserIdHeaderKeysAsList(WingtipsSpringBoot2WebfluxProperties props) {

--- a/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsSpringBoot2WebfluxConfiguration.java
+++ b/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsSpringBoot2WebfluxConfiguration.java
@@ -133,6 +133,16 @@ public class WingtipsSpringBoot2WebfluxConfiguration {
             .build();
     }
 
+    /**
+     * This bean registers a reactor-core {@link reactor.core.scheduler.Scheduler}
+     * hook, which ensures that Wingtip trace, spans {@link reactor.core.publisher.Mono}
+     * and {@link reactor.core.publisher.Flux} based async boundaries.
+     */
+    @Bean
+    public WingtipsReactorInitializer reactorInitializer() {
+        return new WingtipsReactorInitializer();
+    }
+
     protected @Nullable List<String> extractUserIdHeaderKeysAsList(WingtipsSpringBoot2WebfluxProperties props) {
         if (props.getUserIdHeaderKeys() == null) {
             return null;

--- a/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsSpringBoot2WebfluxConfiguration.java
+++ b/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsSpringBoot2WebfluxConfiguration.java
@@ -141,10 +141,7 @@ public class WingtipsSpringBoot2WebfluxConfiguration {
      */
     @Bean
     public WingtipsReactorInitializer reactorInitializer(WingtipsSpringBoot2WebfluxProperties props) {
-        if (props.isReactorEnabled()) {
-            return new WingtipsReactorInitializer();
-        }
-        return null;
+        return new WingtipsReactorInitializer(props.isReactorEnabled());
     }
 
     protected @Nullable List<String> extractUserIdHeaderKeysAsList(WingtipsSpringBoot2WebfluxProperties props) {

--- a/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsSpringBoot2WebfluxProperties.java
+++ b/wingtips-spring-boot2-webflux/src/main/java/com/nike/wingtips/springboot2/webflux/WingtipsSpringBoot2WebfluxProperties.java
@@ -52,7 +52,10 @@ import java.util.List;
  *         however you can pass in a fully qualified class name for this property if you have a custom impl you want
  *         to use.
  *     </li>
- * </ul>
+ *     <li>
+ *         wingtips.reactor-enabled - Enables passing the Wingtips trace details across
+ *         Project Reactors async boundaries. This is disabled by default.
+ *     </li> * </ul>
  *
  * <p>For example you could set the following properties in your {@code application.properties}:
  * <pre>
@@ -72,6 +75,7 @@ public class WingtipsSpringBoot2WebfluxProperties {
     private Tracer.SpanLoggingRepresentation spanLoggingFormat;
     private String serverSideSpanTaggingStrategy;
     private String serverSideSpanTaggingAdapter;
+    private boolean reactorEnabled = false;
 
     public boolean isWingtipsDisabled() {
         return wingtipsDisabled;
@@ -111,5 +115,13 @@ public class WingtipsSpringBoot2WebfluxProperties {
 
     public void setServerSideSpanTaggingAdapter(String serverSideSpanTaggingAdapter) {
         this.serverSideSpanTaggingAdapter = serverSideSpanTaggingAdapter;
+    }
+
+    public boolean isReactorEnabled() {
+        return reactorEnabled;
+    }
+
+    public void setReactorEnabled(boolean reactorEnabled) {
+        this.reactorEnabled = reactorEnabled;
     }
 }

--- a/wingtips-spring-boot2-webflux/src/test/java/com/nike/wingtips/springboot2/webflux/WingtipsSpringBoot2WebfluxConfigurationTest.java
+++ b/wingtips-spring-boot2-webflux/src/test/java/com/nike/wingtips/springboot2/webflux/WingtipsSpringBoot2WebfluxConfigurationTest.java
@@ -552,6 +552,7 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
             //then
             assertThat(asyncTraceId.block()).isEqualTo(Optional.empty());
         } finally {
+            Schedulers.removeExecutorServiceDecorator(WingtipsReactorInitializer.WINGTIPS_SCHEDULER_KEY);
             SpringApplication.exit(serverAppContext);
         }
     }

--- a/wingtips-spring-boot2-webflux/src/test/java/com/nike/wingtips/springboot2/webflux/WingtipsSpringBoot2WebfluxConfigurationTest.java
+++ b/wingtips-spring-boot2-webflux/src/test/java/com/nike/wingtips/springboot2/webflux/WingtipsSpringBoot2WebfluxConfigurationTest.java
@@ -6,6 +6,7 @@ import com.nike.wingtips.Tracer.SpanLoggingRepresentation;
 import com.nike.wingtips.spring.webflux.server.SpringWebfluxServerRequestTagAdapter;
 import com.nike.wingtips.spring.webflux.server.WingtipsSpringWebfluxWebFilter;
 import com.nike.wingtips.springboot2.webflux.componenttest.componentscanonly.ComponentTestMainWithComponentScanOnly;
+import com.nike.wingtips.springboot2.webflux.componenttest.reactordisabled.ComponentTestMainManualImportNoReactorSupport;
 import com.nike.wingtips.springboot2.webflux.componenttest.manualimportandcomponentscan.ComponentTestMainWithBothManualImportAndComponentScan;
 import com.nike.wingtips.springboot2.webflux.componenttest.manualimportonly.ComponentTestMainManualImportOnly;
 import com.nike.wingtips.tags.HttpTagAndSpanNamingAdapter;
@@ -34,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -55,11 +57,11 @@ import static org.mockito.Mockito.mock;
 public class WingtipsSpringBoot2WebfluxConfigurationTest {
 
     private WingtipsSpringBoot2WebfluxProperties generateProps(
-        boolean disabled,
-        String userIdHeaderKeys,
-        SpanLoggingRepresentation spanLoggingFormat,
-        String tagAndNamingStrategy,
-        String tagAndNamingAdapter
+            boolean disabled,
+            String userIdHeaderKeys,
+            SpanLoggingRepresentation spanLoggingFormat,
+            String tagAndNamingStrategy,
+            String tagAndNamingAdapter
     ) {
         WingtipsSpringBoot2WebfluxProperties props = new WingtipsSpringBoot2WebfluxProperties();
         props.setWingtipsDisabled(String.valueOf(disabled));
@@ -71,20 +73,20 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
     }
 
     @DataProvider(value = {
-        "JSON",
-        "KEY_VALUE",
-        "null"
+            "JSON",
+            "KEY_VALUE",
+            "null"
     })
     @Test
     public void constructor_works_as_expected(SpanLoggingRepresentation spanLoggingFormat) {
         // given
         WingtipsSpringBoot2WebfluxProperties props = generateProps(
-            false, UUID.randomUUID().toString(), spanLoggingFormat, "someTagStrategy", "someTagAdapter"
+                false, UUID.randomUUID().toString(), spanLoggingFormat, "someTagStrategy", "someTagAdapter"
         );
         SpanLoggingRepresentation existingSpanLoggingFormat = Tracer.getInstance().getSpanLoggingRepresentation();
         SpanLoggingRepresentation expectedSpanLoggingFormat = (spanLoggingFormat == null)
-                                                              ? existingSpanLoggingFormat
-                                                              : spanLoggingFormat;
+                ? existingSpanLoggingFormat
+                : spanLoggingFormat;
 
         // when
         WingtipsSpringBoot2WebfluxConfiguration conf = new WingtipsSpringBoot2WebfluxConfiguration(props);
@@ -149,33 +151,35 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
     }
 
     @SuppressWarnings("WeakerAccess")
-    static class CustomTagStrategy extends ZipkinHttpTagStrategy<ServerWebExchange, ServerHttpResponse> {}
+    static class CustomTagStrategy extends ZipkinHttpTagStrategy<ServerWebExchange, ServerHttpResponse> {
+    }
 
     @SuppressWarnings("WeakerAccess")
-    static class CustomTagAdapter extends SpringWebfluxServerRequestTagAdapter {}
+    static class CustomTagAdapter extends SpringWebfluxServerRequestTagAdapter {
+    }
 
     @DataProvider(value = {
-        "true   |   USER_ID_HEADER_KEYS_PROP_IS_SET",
-        "true   |   TAG_AND_NAMING_STRATEGY_PROP_IS_SET",
-        "true   |   TAG_AND_NAMING_ADAPTER_PROP_IS_SET",
-        "true   |   ALL_PROPS_ARE_SET",
-        "false  |   USER_ID_HEADER_KEYS_PROP_IS_SET",
-        "false  |   TAG_AND_NAMING_STRATEGY_PROP_IS_SET",
-        "false  |   TAG_AND_NAMING_ADAPTER_PROP_IS_SET",
-        "false  |   ALL_PROPS_ARE_SET"
+            "true   |   USER_ID_HEADER_KEYS_PROP_IS_SET",
+            "true   |   TAG_AND_NAMING_STRATEGY_PROP_IS_SET",
+            "true   |   TAG_AND_NAMING_ADAPTER_PROP_IS_SET",
+            "true   |   ALL_PROPS_ARE_SET",
+            "false  |   USER_ID_HEADER_KEYS_PROP_IS_SET",
+            "false  |   TAG_AND_NAMING_STRATEGY_PROP_IS_SET",
+            "false  |   TAG_AND_NAMING_ADAPTER_PROP_IS_SET",
+            "false  |   ALL_PROPS_ARE_SET"
     }, splitBy = "\\|")
     @SuppressWarnings("unchecked")
     @Test
     public void wingtipsRequestTracingFilter_returns_WingtipsSpringWebfluxWebFilter_with_expected_values(
-        boolean appFilterOverrideIsNull, PropertiesScenario scenario
+            boolean appFilterOverrideIsNull, PropertiesScenario scenario
     ) {
         // given
         WingtipsSpringWebfluxWebFilter appFilterOverride = (appFilterOverrideIsNull)
-                                                           ? null
-                                                           : mock(WingtipsSpringWebfluxWebFilter.class);
+                ? null
+                : mock(WingtipsSpringWebfluxWebFilter.class);
 
         WingtipsSpringBoot2WebfluxProperties props = generateProps(
-            false, scenario.userIdHeaderKeys, null, scenario.tagAndNamingStrategy, scenario.tagAndNamingAdapter
+                false, scenario.userIdHeaderKeys, null, scenario.tagAndNamingStrategy, scenario.tagAndNamingAdapter
         );
         WingtipsSpringBoot2WebfluxConfiguration conf = new WingtipsSpringBoot2WebfluxConfiguration(props);
         conf.customSpringWebfluxWebFilter = appFilterOverride;
@@ -186,25 +190,24 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
         // then
         if (appFilterOverride == null) {
             assertThat(filterBean)
-                .isNotNull()
-                .isInstanceOf(WingtipsSpringWebfluxWebFilter.class);
+                    .isNotNull()
+                    .isInstanceOf(WingtipsSpringWebfluxWebFilter.class);
 
             List<String> filterBeanUserIdHeaderKeys =
-                (List<String>) Whitebox.getInternalState(filterBean, "userIdHeaderKeys");
+                    (List<String>) Whitebox.getInternalState(filterBean, "userIdHeaderKeys");
             HttpTagAndSpanNamingStrategy<ServerWebExchange, ServerHttpResponse> filterBeanTagStrategy =
-                (HttpTagAndSpanNamingStrategy<ServerWebExchange, ServerHttpResponse>)
-                    Whitebox.getInternalState(filterBean, "tagAndNamingStrategy");
+                    (HttpTagAndSpanNamingStrategy<ServerWebExchange, ServerHttpResponse>)
+                            Whitebox.getInternalState(filterBean, "tagAndNamingStrategy");
             HttpTagAndSpanNamingAdapter<ServerWebExchange, ServerHttpResponse> filterBeanTagAdapter =
-                (HttpTagAndSpanNamingAdapter<ServerWebExchange, ServerHttpResponse>)
-                    Whitebox.getInternalState(filterBean, "tagAndNamingAdapter");
+                    (HttpTagAndSpanNamingAdapter<ServerWebExchange, ServerHttpResponse>)
+                            Whitebox.getInternalState(filterBean, "tagAndNamingAdapter");
 
             assertThat(filterBeanUserIdHeaderKeys).isEqualTo(scenario.getExpectedUserIdHeaderKeyList());
             assertThat(filterBeanTagStrategy).isInstanceOf(scenario.getExpectedTagStrategyClass());
             assertThat(filterBeanTagAdapter).isInstanceOf(scenario.getExpectedTagAdapterClass());
 
             assertThat(filterBean.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE);
-        }
-        else {
+        } else {
             assertThat(filterBean).isNull();
         }
     }
@@ -226,8 +229,8 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
         SINGLE_VALUE_HEADERS_STRING("foo", singletonList("foo")),
         MULTIPLE_VALUE_HEADERS_STRING("foo,bar", Arrays.asList("foo", "bar")),
         MULTIPLE_VALUES_WITH_BLANK_AND_EMPTY_ENTRIES(
-            "foo, bar,  baz  ,,  , \r\n\t ,blah",
-            Arrays.asList("foo", "bar", "baz", "blah")
+                "foo, bar,  baz  ,,  , \r\n\t ,blah",
+                Arrays.asList("foo", "bar", "baz", "blah")
         );
 
         public final String userIdHeaderKeysString;
@@ -242,18 +245,18 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
     @DataProvider
     public static List<List<ExtractUserIdHeaderKeysScenario>> extractUserIdHeaderKeysScenarioDataProvider() {
         return Stream.of(ExtractUserIdHeaderKeysScenario.values())
-                     .map(Collections::singletonList)
-                     .collect(Collectors.toList());
+                .map(Collections::singletonList)
+                .collect(Collectors.toList());
     }
 
     @UseDataProvider("extractUserIdHeaderKeysScenarioDataProvider")
     @Test
     public void extractUserIdHeaderKeysAsList_works_as_expected(
-        ExtractUserIdHeaderKeysScenario scenario
+            ExtractUserIdHeaderKeysScenario scenario
     ) {
         // given
         WingtipsSpringBoot2WebfluxProperties props = generateProps(
-            false, scenario.userIdHeaderKeysString, null, null, null
+                false, scenario.userIdHeaderKeysString, null, null, null
         );
         WingtipsSpringBoot2WebfluxConfiguration conf = new WingtipsSpringBoot2WebfluxConfiguration(props);
 
@@ -270,46 +273,46 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
         EMPTY_STRATEGY_NAME(null, null, null),
         BLANK_STRATEGY_NAME(null, null, null),
         ZIPKIN_ALL_CAPS_SHORTNAME(
-            "ZIPKIN", ZipkinHttpTagStrategy.class, ZipkinHttpTagStrategy.getDefaultInstance()
+                "ZIPKIN", ZipkinHttpTagStrategy.class, ZipkinHttpTagStrategy.getDefaultInstance()
         ),
         ZIPKIN_LOWERCASE_SHORTNAME(
-            "zipkin", ZipkinHttpTagStrategy.class, ZipkinHttpTagStrategy.getDefaultInstance()
+                "zipkin", ZipkinHttpTagStrategy.class, ZipkinHttpTagStrategy.getDefaultInstance()
         ),
         ZIPKIN_MIXED_CASE_SHORTNAME(
-            "zIpKiN", ZipkinHttpTagStrategy.class, ZipkinHttpTagStrategy.getDefaultInstance()
+                "zIpKiN", ZipkinHttpTagStrategy.class, ZipkinHttpTagStrategy.getDefaultInstance()
         ),
         OT_ALL_CAPS_SHORTNAME(
-            "OPENTRACING", OpenTracingHttpTagStrategy.class, OpenTracingHttpTagStrategy.getDefaultInstance()
+                "OPENTRACING", OpenTracingHttpTagStrategy.class, OpenTracingHttpTagStrategy.getDefaultInstance()
         ),
         OT_LOWERCASE_SHORTNAME(
-            "opentracing", OpenTracingHttpTagStrategy.class, OpenTracingHttpTagStrategy.getDefaultInstance()
+                "opentracing", OpenTracingHttpTagStrategy.class, OpenTracingHttpTagStrategy.getDefaultInstance()
         ),
         OT_MIXED_CASE_SHORTNAME(
-            "oPeNtRaCiNg", OpenTracingHttpTagStrategy.class, OpenTracingHttpTagStrategy.getDefaultInstance()
+                "oPeNtRaCiNg", OpenTracingHttpTagStrategy.class, OpenTracingHttpTagStrategy.getDefaultInstance()
         ),
         NONE_ALL_CAPS_SHORTNAME(
-            "NONE", NoOpHttpTagStrategy.class, NoOpHttpTagStrategy.getDefaultInstance()
+                "NONE", NoOpHttpTagStrategy.class, NoOpHttpTagStrategy.getDefaultInstance()
         ),
         NONE_LOWERCASE_SHORTNAME(
-            "none", NoOpHttpTagStrategy.class, NoOpHttpTagStrategy.getDefaultInstance()
+                "none", NoOpHttpTagStrategy.class, NoOpHttpTagStrategy.getDefaultInstance()
         ),
         NONE_MIXED_CASE_SHORTNAME(
-            "nOnE", NoOpHttpTagStrategy.class, NoOpHttpTagStrategy.getDefaultInstance()
+                "nOnE", NoOpHttpTagStrategy.class, NoOpHttpTagStrategy.getDefaultInstance()
         ),
         NOOP_ALL_CAPS_SHORTNAME(
-            "NOOP", NoOpHttpTagStrategy.class, NoOpHttpTagStrategy.getDefaultInstance()
+                "NOOP", NoOpHttpTagStrategy.class, NoOpHttpTagStrategy.getDefaultInstance()
         ),
         NOOP_LOWERCASE_SHORTNAME(
-            "noop", NoOpHttpTagStrategy.class, NoOpHttpTagStrategy.getDefaultInstance()
+                "noop", NoOpHttpTagStrategy.class, NoOpHttpTagStrategy.getDefaultInstance()
         ),
         NOOP_MIXED_CASE_SHORTNAME(
-            "nOoP", NoOpHttpTagStrategy.class, NoOpHttpTagStrategy.getDefaultInstance()
+                "nOoP", NoOpHttpTagStrategy.class, NoOpHttpTagStrategy.getDefaultInstance()
         ),
         CUSTOM_BY_CLASSNAME(
-            CustomTagStrategy.class.getName(), CustomTagStrategy.class, null
+                CustomTagStrategy.class.getName(), CustomTagStrategy.class, null
         ),
         INVALID_CLASSNAME(
-            UUID.randomUUID().toString(), null, null
+                UUID.randomUUID().toString(), null, null
         );
 
         public final String strategyName;
@@ -317,9 +320,9 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
         public final HttpTagAndSpanNamingStrategy<ServerWebExchange, ServerHttpResponse> expectedExactMatch;
 
         ExtractTagAndNamingStrategyScenario(
-            String strategyName,
-            Class<? extends HttpTagAndSpanNamingStrategy> expectedResultClass,
-            HttpTagAndSpanNamingStrategy<ServerWebExchange, ServerHttpResponse> expectedExactMatch
+                String strategyName,
+                Class<? extends HttpTagAndSpanNamingStrategy> expectedResultClass,
+                HttpTagAndSpanNamingStrategy<ServerWebExchange, ServerHttpResponse> expectedExactMatch
         ) {
             this.strategyName = strategyName;
             this.expectedResultClass = expectedResultClass;
@@ -330,30 +333,29 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
     @DataProvider
     public static List<List<ExtractTagAndNamingStrategyScenario>> extractTagAndNamingStrategyScenarioDataProvider() {
         return Stream.of(ExtractTagAndNamingStrategyScenario.values())
-                     .map(Collections::singletonList)
-                     .collect(Collectors.toList());
+                .map(Collections::singletonList)
+                .collect(Collectors.toList());
     }
 
     @UseDataProvider("extractTagAndNamingStrategyScenarioDataProvider")
     @Test
     public void extractTagAndNamingStrategy_works_as_expected(
-        ExtractTagAndNamingStrategyScenario scenario
+            ExtractTagAndNamingStrategyScenario scenario
     ) {
         // given
         WingtipsSpringBoot2WebfluxProperties props = generateProps(
-            false, null, null, scenario.strategyName, null
+                false, null, null, scenario.strategyName, null
         );
         WingtipsSpringBoot2WebfluxConfiguration conf = new WingtipsSpringBoot2WebfluxConfiguration(props);
 
         // when
         HttpTagAndSpanNamingStrategy<ServerWebExchange, ServerHttpResponse> result =
-            conf.extractTagAndNamingStrategy(props);
+                conf.extractTagAndNamingStrategy(props);
 
         // then
         if (scenario.expectedResultClass == null) {
             assertThat(result).isNull();
-        }
-        else {
+        } else {
             assertThat(result).isNotNull();
             assertThat(result.getClass()).isEqualTo(scenario.expectedResultClass);
         }
@@ -369,18 +371,18 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
         EMPTY_ADAPTER_NAME(null, null),
         BLANK_ADAPTER_NAME(null, null),
         CUSTOM_BY_CLASSNAME(
-            CustomTagAdapter.class.getName(), CustomTagAdapter.class
+                CustomTagAdapter.class.getName(), CustomTagAdapter.class
         ),
         INVALID_CLASSNAME(
-            UUID.randomUUID().toString(), null
+                UUID.randomUUID().toString(), null
         );
 
         public final String adapterName;
         public final Class<? extends HttpTagAndSpanNamingAdapter> expectedResultClass;
 
         ExtractTagAndNamingAdapterScenario(
-            String adapterName,
-            Class<? extends HttpTagAndSpanNamingAdapter> expectedResultClass
+                String adapterName,
+                Class<? extends HttpTagAndSpanNamingAdapter> expectedResultClass
         ) {
             this.adapterName = adapterName;
             this.expectedResultClass = expectedResultClass;
@@ -390,30 +392,29 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
     @DataProvider
     public static List<List<ExtractTagAndNamingAdapterScenario>> extractTagAndNamingAdapterScenarioDataProvider() {
         return Stream.of(ExtractTagAndNamingAdapterScenario.values())
-                     .map(Collections::singletonList)
-                     .collect(Collectors.toList());
+                .map(Collections::singletonList)
+                .collect(Collectors.toList());
     }
 
     @UseDataProvider("extractTagAndNamingAdapterScenarioDataProvider")
     @Test
     public void extractTagAndNamingAdapter_works_as_expected(
-        ExtractTagAndNamingAdapterScenario scenario
+            ExtractTagAndNamingAdapterScenario scenario
     ) {
         // given
         WingtipsSpringBoot2WebfluxProperties props = generateProps(
-            false, null, null, null, scenario.adapterName
+                false, null, null, null, scenario.adapterName
         );
         WingtipsSpringBoot2WebfluxConfiguration conf = new WingtipsSpringBoot2WebfluxConfiguration(props);
 
         // when
         HttpTagAndSpanNamingAdapter<ServerWebExchange, ServerHttpResponse> result =
-            conf.extractTagAndNamingAdapter(props);
+                conf.extractTagAndNamingAdapter(props);
 
         // then
         if (scenario.expectedResultClass == null) {
             assertThat(result).isNull();
-        }
-        else {
+        } else {
             assertThat(result).isNotNull();
             assertThat(result.getClass()).isEqualTo(scenario.expectedResultClass);
         }
@@ -423,6 +424,7 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
     private enum ComponentTestSetup {
         MANUAL_IMPORT_ONLY(ComponentTestMainManualImportOnly.class, false),
         COMPONENT_SCAN_ONLY(ComponentTestMainWithComponentScanOnly.class, true),
+        COMPONENT_SCAN_WITHOUT_REACTOR_SUPPORT(ComponentTestMainManualImportNoReactorSupport.class, true),
         BOTH_MANUAL_AND_COMPONENT_SCAN(ComponentTestMainWithBothManualImportAndComponentScan.class, true);
 
         final boolean expectComponentScannedObjects;
@@ -439,9 +441,9 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
     //      scanned, imported manually, or both. Specifically we should not get multiple bean definition errors even
     //      when WingtipsSpringBoot2WebfluxConfiguration is *both* component scanned *and* imported manually.
     @DataProvider(value = {
-        "MANUAL_IMPORT_ONLY",
-        "COMPONENT_SCAN_ONLY",
-        "BOTH_MANUAL_AND_COMPONENT_SCAN"
+            "MANUAL_IMPORT_ONLY",
+            "COMPONENT_SCAN_ONLY",
+            "BOTH_MANUAL_AND_COMPONENT_SCAN"
     })
     @Test
     public void component_test(ComponentTestSetup componentTestSetup) {
@@ -449,22 +451,23 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
         int serverPort = findFreePort();
         Class<?> mainClass = componentTestSetup.mainClass;
 
-        ConfigurableApplicationContext serverAppContext = SpringApplication.run(mainClass, "--server.port=" + serverPort);
+        ConfigurableApplicationContext serverAppContext = SpringApplication.run(mainClass,
+                "--server.port=" + serverPort);
 
         try {
             // when
             WingtipsSpringBoot2WebfluxConfiguration
-                config = serverAppContext.getBean(WingtipsSpringBoot2WebfluxConfiguration.class);
-            WingtipsSpringBoot2WebfluxProperties props = serverAppContext.getBean(WingtipsSpringBoot2WebfluxProperties.class);
+                    config = serverAppContext.getBean(WingtipsSpringBoot2WebfluxConfiguration.class);
+            WingtipsSpringBoot2WebfluxProperties props =
+                    serverAppContext.getBean(WingtipsSpringBoot2WebfluxProperties.class);
             String[] someComponentScannedClassBeanNames =
-                serverAppContext.getBeanNamesForType(SomeComponentScannedClass.class);
+                    serverAppContext.getBeanNamesForType(SomeComponentScannedClass.class);
 
             // then
             // Sanity check that we component scanned (or not) as appropriate.
             if (componentTestSetup.expectComponentScannedObjects) {
                 assertThat(someComponentScannedClassBeanNames).isNotEmpty();
-            }
-            else {
+            } else {
                 assertThat(someComponentScannedClassBeanNames).isEmpty();
             }
 
@@ -478,12 +481,11 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
             //      the config.customSpringWebfluxWebFilter field with whatever wingtipsSpringWebfluxWebFilter()
             //      produces - so they should be the same.
             Map<String, WingtipsSpringWebfluxWebFilter> filtersFromSpring =
-                serverAppContext.getBeansOfType(WingtipsSpringWebfluxWebFilter.class);
+                    serverAppContext.getBeansOfType(WingtipsSpringWebfluxWebFilter.class);
             assertThat(filtersFromSpring).isEqualTo(
-                Collections.singletonMap("wingtipsSpringWebfluxWebFilter", config.customSpringWebfluxWebFilter)
+                    Collections.singletonMap("wingtipsSpringWebfluxWebFilter", config.customSpringWebfluxWebFilter)
             );
-        }
-        finally {
+        } finally {
             SpringApplication.exit(serverAppContext);
         }
     }
@@ -499,7 +501,8 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
         int serverPort = findFreePort();
         Class<?> mainClass = componentTestSetup.mainClass;
 
-        ConfigurableApplicationContext serverAppContext = SpringApplication.run(mainClass, "--server.port=" + serverPort);
+        ConfigurableApplicationContext serverAppContext = SpringApplication.run(mainClass,
+                "--server.port=" + serverPort);
 
         try {
             //given
@@ -507,14 +510,44 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
             // when
             Mono<String> asyncTraceId = Mono.just("test")
                     //Set up an async boundary
-                    .subscribeOn(Schedulers.elastic())
+                    .subscribeOn(Schedulers.newElastic("foo"))
                     //Return the traceid
                     .map(s -> Tracer.getInstance().getCurrentSpan().getTraceId());
 
             //then
             assertThat(asyncTraceId.block()).isEqualTo(rootSpan.getTraceId());
+        } finally {
+            SpringApplication.exit(serverAppContext);
         }
-        finally {
+    }
+
+    @DataProvider(value = {
+            "COMPONENT_SCAN_WITHOUT_REACTOR_SUPPORT"
+    })
+    @Test
+    public void reactor_async_trace_propagation_disabled(ComponentTestSetup componentTestSetup) {
+        // given
+        int serverPort = findFreePort();
+        Class<?> mainClass = componentTestSetup.mainClass;
+
+        ConfigurableApplicationContext serverAppContext = SpringApplication.run(mainClass,
+                "--server.port=" + serverPort);
+
+        try {
+            //given
+            final Span rootSpan = Tracer.getInstance().startRequestWithRootSpan("root");
+            // when
+            Mono<Optional<String>> asyncTraceId = Mono.just("test")
+                    //Set up an async boundary
+                    .subscribeOn(Schedulers.newElastic("another"))
+                    //Return the traceid
+                    .map(s -> Tracer.getInstance().getCurrentSpan() != null
+                            ? Optional.of(Tracer.getInstance().getCurrentSpan().getTraceId())
+                            : Optional.empty());
+
+            //then
+            assertThat(asyncTraceId.block()).isEqualTo(Optional.empty());
+        } finally {
             SpringApplication.exit(serverAppContext);
         }
     }
@@ -525,17 +558,18 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
         int serverPort = findFreePort();
 
         ConfigurableApplicationContext serverAppContext = SpringApplication.run(
-            ComponentTestMainWithCustomWingtipsWebFilter.class,
-            "--server.port=" + serverPort
+                ComponentTestMainWithCustomWingtipsWebFilter.class,
+                "--server.port=" + serverPort
         );
 
         try {
             // when
             WingtipsSpringBoot2WebfluxConfiguration
-                config = serverAppContext.getBean(WingtipsSpringBoot2WebfluxConfiguration.class);
-            WingtipsSpringBoot2WebfluxProperties props = serverAppContext.getBean(WingtipsSpringBoot2WebfluxProperties.class);
+                    config = serverAppContext.getBean(WingtipsSpringBoot2WebfluxConfiguration.class);
+            WingtipsSpringBoot2WebfluxProperties props =
+                    serverAppContext.getBean(WingtipsSpringBoot2WebfluxProperties.class);
             String[] someComponentScannedClassBeanNames =
-                serverAppContext.getBeanNamesForType(SomeComponentScannedClass.class);
+                    serverAppContext.getBeanNamesForType(SomeComponentScannedClass.class);
 
             // then
             // Sanity check that we component scanned (or not) as appropriate. This particular component test does
@@ -551,14 +585,13 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
             // Finally, the thing this test is verifying: the config's custom filter should be the same one from the
             //      component test main class, and it should be the one that Spring exposes.
             assertThat(config.customSpringWebfluxWebFilter)
-                .isSameAs(ComponentTestMainWithCustomWingtipsWebFilter.customFilter);
+                    .isSameAs(ComponentTestMainWithCustomWingtipsWebFilter.customFilter);
             Map<String, WingtipsSpringWebfluxWebFilter> filtersFromSpring =
-                serverAppContext.getBeansOfType(WingtipsSpringWebfluxWebFilter.class);
+                    serverAppContext.getBeansOfType(WingtipsSpringWebfluxWebFilter.class);
             assertThat(filtersFromSpring).isEqualTo(
-                Collections.singletonMap("customFilter", ComponentTestMainWithCustomWingtipsWebFilter.customFilter)
+                    Collections.singletonMap("customFilter", ComponentTestMainWithCustomWingtipsWebFilter.customFilter)
             );
-        }
-        finally {
+        } finally {
             SpringApplication.exit(serverAppContext);
         }
     }

--- a/wingtips-spring-boot2-webflux/src/test/java/com/nike/wingtips/springboot2/webflux/WingtipsSpringBoot2WebfluxConfigurationTest.java
+++ b/wingtips-spring-boot2-webflux/src/test/java/com/nike/wingtips/springboot2/webflux/WingtipsSpringBoot2WebfluxConfigurationTest.java
@@ -37,11 +37,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import notcomponentscanned.componenttest.ComponentTestMainWithCustomWingtipsWebFilter;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 import static java.util.Collections.singletonList;
@@ -486,6 +488,7 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
                     Collections.singletonMap("wingtipsSpringWebfluxWebFilter", config.customSpringWebfluxWebFilter)
             );
         } finally {
+            Schedulers.removeExecutorServiceDecorator(WingtipsReactorInitializer.WINGTIPS_SCHEDULER_KEY);
             SpringApplication.exit(serverAppContext);
         }
     }
@@ -517,6 +520,7 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
             //then
             assertThat(asyncTraceId.block()).isEqualTo(rootSpan.getTraceId());
         } finally {
+            Schedulers.removeExecutorServiceDecorator(WingtipsReactorInitializer.WINGTIPS_SCHEDULER_KEY);
             SpringApplication.exit(serverAppContext);
         }
     }
@@ -535,7 +539,7 @@ public class WingtipsSpringBoot2WebfluxConfigurationTest {
 
         try {
             //given
-            final Span rootSpan = Tracer.getInstance().startRequestWithRootSpan("root");
+            Tracer.getInstance().startRequestWithRootSpan("root");
             // when
             Mono<Optional<String>> asyncTraceId = Mono.just("test")
                     //Set up an async boundary

--- a/wingtips-spring-boot2-webflux/src/test/java/com/nike/wingtips/springboot2/webflux/componenttest/componentscanonly/ComponentTestMainWithComponentScanOnly.java
+++ b/wingtips-spring-boot2-webflux/src/test/java/com/nike/wingtips/springboot2/webflux/componenttest/componentscanonly/ComponentTestMainWithComponentScanOnly.java
@@ -2,9 +2,11 @@ package com.nike.wingtips.springboot2.webflux.componenttest.componentscanonly;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.PropertySource;
 
 @SpringBootApplication
 @ComponentScan(basePackages = "com.nike")
+@PropertySource("classpath:/wingtipsAndReactorSupportEnabled.properties")
 public class ComponentTestMainWithComponentScanOnly {
 
     public ComponentTestMainWithComponentScanOnly() {

--- a/wingtips-spring-boot2-webflux/src/test/java/com/nike/wingtips/springboot2/webflux/componenttest/manualimportandcomponentscan/ComponentTestMainWithBothManualImportAndComponentScan.java
+++ b/wingtips-spring-boot2-webflux/src/test/java/com/nike/wingtips/springboot2/webflux/componenttest/manualimportandcomponentscan/ComponentTestMainWithBothManualImportAndComponentScan.java
@@ -5,9 +5,11 @@ import com.nike.wingtips.springboot2.webflux.WingtipsSpringBoot2WebfluxConfigura
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
 
 @SpringBootApplication
 @Import(WingtipsSpringBoot2WebfluxConfiguration.class)
+@PropertySource("classpath:/wingtipsAndReactorSupportEnabled.properties")
 @ComponentScan(basePackages = "com.nike")
 public class ComponentTestMainWithBothManualImportAndComponentScan {
 

--- a/wingtips-spring-boot2-webflux/src/test/java/com/nike/wingtips/springboot2/webflux/componenttest/manualimportonly/ComponentTestMainManualImportOnly.java
+++ b/wingtips-spring-boot2-webflux/src/test/java/com/nike/wingtips/springboot2/webflux/componenttest/manualimportonly/ComponentTestMainManualImportOnly.java
@@ -4,9 +4,11 @@ import com.nike.wingtips.springboot2.webflux.WingtipsSpringBoot2WebfluxConfigura
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
 
 @SpringBootApplication
 @Import(WingtipsSpringBoot2WebfluxConfiguration.class)
+@PropertySource("classpath:/wingtipsAndReactorSupportEnabled.properties")
 public class ComponentTestMainManualImportOnly {
 
     public ComponentTestMainManualImportOnly() {

--- a/wingtips-spring-boot2-webflux/src/test/java/com/nike/wingtips/springboot2/webflux/componenttest/reactordisabled/ComponentTestMainManualImportNoReactorSupport.java
+++ b/wingtips-spring-boot2-webflux/src/test/java/com/nike/wingtips/springboot2/webflux/componenttest/reactordisabled/ComponentTestMainManualImportNoReactorSupport.java
@@ -1,0 +1,13 @@
+package com.nike.wingtips.springboot2.webflux.componenttest.reactordisabled;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.PropertySource;
+
+@SpringBootApplication
+@PropertySource("classpath:/wingtipsAndReactorSupportDisabled.properties")
+public class ComponentTestMainManualImportNoReactorSupport {
+
+    public ComponentTestMainManualImportNoReactorSupport() {
+    }
+
+}

--- a/wingtips-spring-boot2-webflux/src/test/resources/wingtipsAndReactorSupportDisabled.properties
+++ b/wingtips-spring-boot2-webflux/src/test/resources/wingtipsAndReactorSupportDisabled.properties
@@ -1,0 +1,2 @@
+# Should be disabled by default
+# wingtips.reactor-enabled=false

--- a/wingtips-spring-boot2-webflux/src/test/resources/wingtipsAndReactorSupportEnabled.properties
+++ b/wingtips-spring-boot2-webflux/src/test/resources/wingtipsAndReactorSupportEnabled.properties
@@ -1,0 +1,1 @@
+wingtips.reactor-enabled=true


### PR DESCRIPTION
Spring's [project-reactor](https://projectreactor.io/) provides a powerful set of operators that abstracts some of the async operations behind simple functions like map, flatMap. This PR adds support for propagating tracing details across thread boundaries when using reactor's operators.