### PR TITLE
Fix wingtips-to-zipkin conversion with regards to null tag or annotation keys or values

### DIFF
--- a/wingtips-zipkin2/src/main/java/com/nike/wingtips/zipkin2/WingtipsToZipkinLifecycleListener.java
+++ b/wingtips-zipkin2/src/main/java/com/nike/wingtips/zipkin2/WingtipsToZipkinLifecycleListener.java
@@ -179,10 +179,11 @@ public class WingtipsToZipkinLifecycleListener implements SpanLifecycleListener 
                 //      malicious caller to endlessly spam the logs.
                 lastSpanHandlingErrorLogTimeEpochMillis = currentTimeMillis;
 
+                String exAsString = ex.toString();
                 zipkinConversionOrReportingErrorLogger.warn(
                     "There have been {} spans that were not Zipkin compatible, or that experienced an error during span handling. Latest example: "
                     + "wingtips_span_with_error=\"{}\", conversion_or_handling_error=\"{}\"",
-                    currentBadSpanCount, span.toKeyValueString(), ex.toString());
+                    currentBadSpanCount, span.toKeyValueString(), exAsString, ex);
             }
         }
     }

--- a/wingtips-zipkin2/src/test/java/com/nike/wingtips/zipkin2/WingtipsToZipkinLifecycleListenerTest.java
+++ b/wingtips-zipkin2/src/test/java/com/nike/wingtips/zipkin2/WingtipsToZipkinLifecycleListenerTest.java
@@ -25,6 +25,7 @@ import zipkin2.reporter.urlconnection.URLConnectionSender;
 import static com.nike.wingtips.zipkin2.WingtipsToZipkinLifecycleListener.MIN_SPAN_HANDLING_ERROR_LOG_INTERVAL_MILLIS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
@@ -169,7 +170,8 @@ public class WingtipsToZipkinLifecycleListenerTest {
         Whitebox.setInternalState(listener, "zipkinConversionOrReportingErrorLogger", loggerMock);
         long lastLogTimeToSet = System.currentTimeMillis() - (MIN_SPAN_HANDLING_ERROR_LOG_INTERVAL_MILLIS + 10);
         Whitebox.setInternalState(listener, "lastSpanHandlingErrorLogTimeEpochMillis", lastLogTimeToSet);
-        doThrow(new RuntimeException("kaboom")).when(spanReporterMock).report(any());
+        Throwable ex = new RuntimeException("kaboom");
+        doThrow(ex).when(spanReporterMock).report(any());
 
         // when
         long before = System.currentTimeMillis();
@@ -177,7 +179,7 @@ public class WingtipsToZipkinLifecycleListenerTest {
         long after = System.currentTimeMillis();
 
         // then
-        verify(loggerMock).warn(anyString(), anyLong(), any(), anyString());
+        verify(loggerMock).warn(anyString(), anyLong(), any(), anyString(), eq(ex));
         // Also verify that the lastSpanHandlingErrorLogTimeEpochMillis value got updated.
         assertThat((long)Whitebox.getInternalState(listener, "lastSpanHandlingErrorLogTimeEpochMillis")).isBetween(before, after);
     }


### PR DESCRIPTION
Also include the stack trace in the rate-limited conversion error log message.